### PR TITLE
Add option to show silenced and inhibited alerts

### DIFF
--- a/Alertmanager/Alerts.swift
+++ b/Alertmanager/Alerts.swift
@@ -68,7 +68,7 @@ class Alerts {
         // Load the alert groups for each configured alertmanager.
         for alertmanager in self.config.alertmanagers {
             let session = URLSession.shared
-            let url = URL(string: alertmanager.url + "/api/v2/alerts/groups")!
+            let url = URL(string: alertmanager.url + "/api/v2/alerts/groups?silenced=" + alertmanager.silenced + "&inhibited=" + alertmanager.inhibited)!
 
             var request = URLRequest(url: url)
             request.httpMethod = "GET"

--- a/Alertmanager/Models.swift
+++ b/Alertmanager/Models.swift
@@ -57,6 +57,8 @@ typealias Alertmanagers = [Alertmanager]
 struct Alertmanager: Codable {
     var name: String
     var url: String
+    var silenced: String
+    var inhibited: String
     var authType: String
     var authUsername: String
     var authPassword: String
@@ -68,6 +70,8 @@ struct Alertmanager: Codable {
         
         self.name = try values.decode(String.self, forKey: .name)
         self.url = try values.decode(String.self, forKey: .url)
+        self.silenced = try values.decodeIfPresent(String.self, forKey: .silenced) ?? "false"
+        self.inhibited = try values.decodeIfPresent(String.self, forKey: .inhibited) ?? "false"
         self.authType = try values.decodeIfPresent(String.self, forKey: .authType) ?? ""
         self.authUsername = try values.decodeIfPresent(String.self, forKey: .authUsername) ?? ""
         self.authPassword = try values.decodeIfPresent(String.self, forKey: .authPassword) ?? ""

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Rico Berger
+Copyright (c) 2020 Rico Berger
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ You can configure the following values for the Alertmanager app:
 | ----- | ----------- | ------- |
 | `name` | Name of the Alertmanager. | **Required** |
 | `url` | URL of the Alertmanager. | **Required** |
+| `silenced` | Show silenced alerts. Must be `true` or `false` as *string*. | `false` |
+| `inhibited` | Show inhibited alerts. Must be `true` or `false` as *string*. | `false` |
 | `authType` | Authentication method which should be used to retrieve alerts. Possible values are `basic` and `token`. If not authentication is required omit this field. | |
 | `authUsername` | If basic auth is used this is the username which should be used. | |
 | `authPassword` | If basic auth is used this is the password which should be used. | |


### PR DESCRIPTION
The Alertmanager configuration contains two new fields: `silenced` and `inhibited`, to show/hide silenced and inhibited alerts.

The only valid options for these fields are `true` and `false`, the default is `false`. The values must be strings not booleans.

Closes #1.