### PR TITLE
feat: check for new app version on launch

### DIFF
--- a/Alertmanager/AlertmanagerApp.swift
+++ b/Alertmanager/AlertmanagerApp.swift
@@ -49,6 +49,10 @@ struct AlertmanagerApp: App {
             ContentView()
                 .onAppear {
                     NotificationService.shared.configure(with: sharedModelContainer)
+                    // One-shot version probe against the GitHub releases
+                    // API. Subsequent `.onAppear` calls within the same
+                    // session are no-ops — the banner is a launch hint.
+                    UpdateCheckService.shared.checkForUpdate()
                 }
         }
         .modelContainer(sharedModelContainer)

--- a/Alertmanager/ContentView.swift
+++ b/Alertmanager/ContentView.swift
@@ -67,6 +67,15 @@ struct ContentView: View {
     /// been closed.
     @State private var notificationAlertNotFound = false
 
+    /// Observes the singleton update-check service. The published
+    /// `availableUpdate` drives the bottom-trailing "Update available"
+    /// banner overlay.
+    @StateObject private var updateCheck = UpdateCheckService.shared
+
+    /// Per-session dismissal of the update banner. Reset on next launch so
+    /// the banner reappears if the update is still applicable.
+    @State private var updateBannerDismissed = false
+
     var body: some View {
         NavigationSplitView {
             VStack(spacing: 0) {
@@ -116,10 +125,25 @@ struct ContentView: View {
                 ContentUnavailableView(
                     "Alert Not Found",
                     systemImage: "bell.slash",
-                    description: Text("The alert could not be found. It may have already been resolved or expired.")
+                    description: Text(
+                        "The alert could not be found. It may have already been resolved or expired."
+                    )
                 )
             }
         }
+        .overlay(alignment: .bottom) {
+            // Launch-time update notice. Only rendered when the version
+            // probe has reported a newer release *and* the user hasn't
+            // dismissed it in this session.
+            if let update = updateCheck.availableUpdate, !updateBannerDismissed {
+                UpdateAvailableBanner(update: update) {
+                    updateBannerDismissed = true
+                }
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: updateCheck.availableUpdate)
+        .animation(.easeInOut(duration: 0.2), value: updateBannerDismissed)
         .sheet(isPresented: $showingAddAlertmanager) {
             NavigationStack {
                 AlertmanagerFormView()
@@ -208,7 +232,9 @@ struct ContentView: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("This will delete all alertmanagers and filters, and restore default settings. This action cannot be undone.")
+            Text(
+                "This will delete all alertmanagers and filters, and restore default settings. This action cannot be undone."
+            )
         }
     }
 
@@ -223,8 +249,10 @@ struct ContentView: View {
     /// is set so the detail column can show an appropriate hint.
     private func resolvePendingAlertDetail() {
         guard let pending = pendingAlertDetail else { return }
-        guard let alertmanager = alertmanagers.first(where: { $0.id == pending.alertmanagerID }) else { return }
-        guard let alert = AlertsManager.shared.alertsByAlertmanager[pending.alertmanagerID]?
+        guard let alertmanager = alertmanagers.first(where: { $0.id == pending.alertmanagerID })
+        else { return }
+        guard
+            let alert = AlertsManager.shared.alertsByAlertmanager[pending.alertmanagerID]?
                 .first(where: { $0.fingerprint == pending.fingerprint })
         else {
             // The alertmanager is known but the alert is missing from the
@@ -245,7 +273,8 @@ struct ContentView: View {
 
     /// Deletes the alertmanagers at the supplied offsets, first stopping
     /// their polling timers so they don't fire against a deleted model.
-    private func deleteAlertmanagers(offsets: IndexSet) {        withAnimation {
+    private func deleteAlertmanagers(offsets: IndexSet) {
+        withAnimation {
             for index in offsets {
                 let alertmanager = alertmanagers[index]
                 if case .alertmanager(let selected) = selectedItem, selected == alertmanager {
@@ -322,7 +351,8 @@ struct ContentView: View {
     /// contents into the current `modelContext`, and starts polling for any
     /// newly added alertmanagers. Reports the outcome through the
     /// "Import Complete" alert.
-    private func importConfiguration() {        let panel = NSOpenPanel()
+    private func importConfiguration() {
+        let panel = NSOpenPanel()
         panel.allowedContentTypes = [UTType.json]
         panel.allowsMultipleSelection = false
 

--- a/Alertmanager/Services/UpdateCheckService.swift
+++ b/Alertmanager/Services/UpdateCheckService.swift
@@ -1,0 +1,189 @@
+//
+//  UpdateCheckService.swift
+//  Alertmanager
+//
+
+import Combine
+import Foundation
+
+/// Checks the GitHub Releases API for a newer published version of the app.
+///
+/// The app's current version is taken from the `CFBundleShortVersionString`
+/// `Info.plist` entry (the `MARKETING_VERSION` Xcode build setting). The
+/// latest published release tag is fetched from
+/// `https://api.github.com/repos/ricoberger/Alertmanager/releases/latest`.
+///
+/// Singleton because the banner that consumes `availableUpdate` is rendered
+/// in `ContentView`, but the check itself fires from `AlertmanagerApp` on
+/// launch and must outlive any single view.
+@MainActor
+final class UpdateCheckService: ObservableObject {
+    /// Process-wide singleton.
+    static let shared = UpdateCheckService()
+
+    /// Available update, if a newer version was found on GitHub.
+    ///
+    /// `nil` means either the check hasn't run, the network call failed, or
+    /// the installed app is already at the latest released version. The
+    /// banner observes this property and shows/hides itself accordingly.
+    @Published private(set) var availableUpdate: AvailableUpdate?
+
+    /// One-shot guard so `checkForUpdate()` does nothing on subsequent
+    /// launches *within* a single app session — the banner is meant as a
+    /// startup hint, not a polling indicator.
+    private var hasChecked = false
+
+    /// GitHub REST endpoint returning the most recently published release.
+    private static let latestReleaseAPI = URL(
+        string: "https://api.github.com/repos/ricoberger/Alertmanager/releases/latest")!
+
+    private init() {}
+
+    // MARK: - Public API
+
+    /// Information about a newer version available on GitHub.
+    struct AvailableUpdate: Equatable {
+        /// Tag name as returned by GitHub (e.g. `"v1.2.3"`). Displayed
+        /// verbatim in the banner so users see the same string GitHub uses.
+        let latestVersion: String
+        /// The currently running app version (without any `v` prefix), used
+        /// to render the "1.0.0 → 1.2.3" hint.
+        let currentVersion: String
+        /// Canonical web URL for the release, taken from the GitHub API's
+        /// `html_url` field (e.g.
+        /// `https://github.com/ricoberger/Alertmanager/releases/tag/1.4.0`).
+        /// Opened by the banner's "View Release" button.
+        let releaseURL: URL
+    }
+
+    /// Performs the update check at most once per process lifetime.
+    ///
+    /// Safe to call from multiple `.onAppear` handlers — repeated calls
+    /// after the first are no-ops.
+    func checkForUpdate() {
+        guard !hasChecked else { return }
+        hasChecked = true
+
+        Task { [weak self] in
+            await self?.runCheck()
+        }
+    }
+
+    // MARK: - Internals
+
+    /// Resets the "already-checked" guard so the next `checkForUpdate()`
+    /// performs a new network call. Used by tests; not exposed to UI code.
+    func resetForTesting() {
+        hasChecked = false
+        availableUpdate = nil
+    }
+
+    private func runCheck() async {
+        guard let current = Self.currentAppVersion() else {
+            print("UpdateCheckService: could not read CFBundleShortVersionString; skipping check")
+            return
+        }
+
+        do {
+            var request = URLRequest(url: Self.latestReleaseAPI)
+            // GitHub recommends a custom UA + the v3 Accept header.
+            request.setValue("Alertmanager-macOS", forHTTPHeaderField: "User-Agent")
+            request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+            request.timeoutInterval = 10
+
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode)
+            else {
+                let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+                print("UpdateCheckService: GitHub returned HTTP \(status); skipping")
+                return
+            }
+
+            let decoded = try JSONDecoder().decode(GitHubRelease.self, from: data)
+            // Drafts and pre-releases are filtered out by the `/latest`
+            // endpoint already, but double-check defensively.
+            guard decoded.draft != true, decoded.prerelease != true else { return }
+
+            let latestTag = decoded.tagName
+            if Self.isNewer(latest: latestTag, current: current) {
+                self.availableUpdate = AvailableUpdate(
+                    latestVersion: latestTag,
+                    currentVersion: current,
+                    releaseURL: decoded.htmlURL
+                )
+            }
+        } catch {
+            print("UpdateCheckService: check failed — \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Version helpers
+
+    /// Reads the running app's `CFBundleShortVersionString` from the main
+    /// bundle. Returns `nil` for unit-test hosts that don't ship a real
+    /// `Info.plist`.
+    private static func currentAppVersion() -> String? {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+    }
+
+    /// Returns `true` when `latest` represents a strictly newer version
+    /// than `current`.
+    ///
+    /// Both arguments may carry a leading `v` (GitHub release tags usually
+    /// do) and any number of dot-separated numeric components. Trailing
+    /// zero components are treated as equal (`1.2` == `1.2.0`). Components
+    /// that fail to parse as integers fall back to a lexicographic
+    /// comparison so non-numeric tags don't accidentally satisfy the
+    /// "newer" test.
+    ///
+    /// Exposed `internal` so it can be exercised directly in unit tests.
+    nonisolated static func isNewer(latest: String, current: String) -> Bool {
+        let l = normalize(latest)
+        let c = normalize(current)
+
+        let lParts = l.split(separator: ".").map(String.init)
+        let cParts = c.split(separator: ".").map(String.init)
+        let count = max(lParts.count, cParts.count)
+
+        for i in 0..<count {
+            let lp = i < lParts.count ? lParts[i] : "0"
+            let cp = i < cParts.count ? cParts[i] : "0"
+            if let li = Int(lp), let ci = Int(cp) {
+                if li > ci { return true }
+                if li < ci { return false }
+            } else {
+                if lp > cp { return true }
+                if lp < cp { return false }
+            }
+        }
+        return false
+    }
+
+    /// Strips a leading `v`/`V` from a tag so `v1.2.3` compares cleanly
+    /// against the bundle's `1.2.3` string.
+    nonisolated private static func normalize(_ version: String) -> String {
+        let trimmed = version.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let first = trimmed.first, first == "v" || first == "V" {
+            return String(trimmed.dropFirst())
+        }
+        return trimmed
+    }
+
+    // MARK: - GitHub response shape
+
+    /// Minimal projection of the `/releases/latest` JSON response. Only the
+    /// fields the update check actually consumes are decoded.
+    private struct GitHubRelease: Decodable {
+        let tagName: String
+        let htmlURL: URL
+        let draft: Bool?
+        let prerelease: Bool?
+
+        enum CodingKeys: String, CodingKey {
+            case tagName = "tag_name"
+            case htmlURL = "html_url"
+            case draft
+            case prerelease
+        }
+    }
+}

--- a/Alertmanager/Views/UpdateAvailableBanner.swift
+++ b/Alertmanager/Views/UpdateAvailableBanner.swift
@@ -1,0 +1,73 @@
+//
+//  UpdateAvailableBanner.swift
+//  Alertmanager
+//
+
+import AppKit
+import SwiftUI
+
+/// Small overlay banner shown at the bottom of the main window when
+/// `UpdateCheckService` has detected a newer release on GitHub.
+///
+/// The banner is rendered as an `.overlay` on top of `ContentView` so it
+/// doesn't reflow the split-view layout. A "View Release" button opens the
+/// specific release page on GitHub in the user's default browser; a
+/// dismiss button closes the banner for the current session only — the
+/// next launch re-checks and re-shows if the update is still applicable.
+struct UpdateAvailableBanner: View {
+    /// The update to advertise. Coming directly from
+    /// `UpdateCheckService.availableUpdate`; the banner only renders when
+    /// this is non-nil at the call site.
+    let update: UpdateCheckService.AvailableUpdate
+
+    /// Invoked when the user taps the dismiss (x) button.
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            Image(systemName: "arrow.down.circle.fill")
+                .font(.title2)
+                .foregroundStyle(.tint)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Update Available")
+                    .font(.headline)
+                Text(
+                    "Version \(update.latestVersion) is available, you are running version \(update.currentVersion)."
+                )
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 8)
+
+            Button {
+                NSWorkspace.shared.open(update.releaseURL)
+            } label: {
+                Text("View Release")
+            }
+            .buttonStyle(.borderedProminent)
+            .accessibilityIdentifier("update-banner-view-release")
+
+            Button {
+                onDismiss()
+            } label: {
+                Image(systemName: "xmark")
+                    .imageScale(.medium)
+            }
+            .buttonStyle(.borderless)
+            .help("Dismiss")
+            .accessibilityIdentifier("update-banner-dismiss")
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.15), radius: 8, x: 0, y: 2)
+        .padding(24)
+        .accessibilityIdentifier("update-banner")
+    }
+}

--- a/AlertmanagerTests/UpdateCheckServiceTests.swift
+++ b/AlertmanagerTests/UpdateCheckServiceTests.swift
@@ -1,0 +1,63 @@
+//
+//  UpdateCheckServiceTests.swift
+//  AlertmanagerTests
+//
+
+import Foundation
+import Testing
+
+@testable import Alertmanager
+
+@Suite("UpdateCheckService.isNewer")
+struct UpdateCheckServiceVersionTests {
+
+    @Test("Higher patch is newer")
+    func higherPatch() {
+        #expect(UpdateCheckService.isNewer(latest: "1.0.1", current: "1.0.0"))
+    }
+
+    @Test("Higher minor is newer")
+    func higherMinor() {
+        #expect(UpdateCheckService.isNewer(latest: "1.1.0", current: "1.0.9"))
+    }
+
+    @Test("Higher major is newer")
+    func higherMajor() {
+        #expect(UpdateCheckService.isNewer(latest: "2.0.0", current: "1.99.99"))
+    }
+
+    @Test("Equal versions are not newer")
+    func equalVersions() {
+        #expect(!UpdateCheckService.isNewer(latest: "1.0.0", current: "1.0.0"))
+    }
+
+    @Test("Lower version is not newer")
+    func lowerVersion() {
+        #expect(!UpdateCheckService.isNewer(latest: "1.0.0", current: "1.0.1"))
+    }
+
+    @Test("Leading v on tag is ignored")
+    func ignoresLeadingV() {
+        #expect(UpdateCheckService.isNewer(latest: "v1.2.0", current: "1.1.9"))
+        #expect(!UpdateCheckService.isNewer(latest: "v1.0.0", current: "1.0.0"))
+    }
+
+    @Test("Trailing zero components count as equal")
+    func trailingZeroComponents() {
+        #expect(!UpdateCheckService.isNewer(latest: "1.2", current: "1.2.0"))
+        #expect(!UpdateCheckService.isNewer(latest: "1.2.0", current: "1.2"))
+        #expect(UpdateCheckService.isNewer(latest: "1.2.0.1", current: "1.2"))
+    }
+
+    @Test("Whitespace around versions is tolerated")
+    func toleratesWhitespace() {
+        #expect(UpdateCheckService.isNewer(latest: "  v1.2.0  ", current: "1.1.0"))
+    }
+
+    @Test("Numeric components compare numerically, not lexicographically")
+    func numericComparison() {
+        // "10" > "9" only when compared as integers — a string compare
+        // would put "10" < "9".
+        #expect(UpdateCheckService.isNewer(latest: "1.10.0", current: "1.9.0"))
+    }
+}


### PR DESCRIPTION
On launch, query the GitHub Releases API for the latest tag and compare
it against the bundle's `CFBundleShortVersionString`. When a newer
version is published, show a small dismissible banner at the bottom of
the main window with a "View Release" button that opens the GitHub
release page.