### PR TITLE
feat(alertmanager-configuration)!: Only allow one grafana alertmanager per alertmanager configuration

### DIFF
--- a/Alertmanager/Models/Alert.swift
+++ b/Alertmanager/Models/Alert.swift
@@ -45,13 +45,6 @@ struct GettableAlert: Codable, Identifiable, Hashable {
     /// URL to the originating system (typically Prometheus) that generated
     /// the alert. Used for the "Source" deep-link in `AlertRowView`.
     let generatorURL: String?
-
-    /// Name of the Grafana-managed Alertmanager this alert was fetched from,
-    /// or `nil` for a standard Prometheus Alertmanager. Set by
-    /// `AlertmanagerService.fetchAlerts(for:)` when iterating over
-    /// `Alertmanager.grafanaAlertmanagers`. Must be preserved end-to-end so
-    /// silence/dashboard deep-links target the correct backend.
-    var grafanaAlertmanagerSource: String?
 }
 
 /// Status block describing an alert's lifecycle state and any active

--- a/Alertmanager/Models/Alertmanager.swift
+++ b/Alertmanager/Models/Alertmanager.swift
@@ -11,8 +11,8 @@ import SwiftData
 ///
 /// An `Alertmanager` describes either a standard Prometheus Alertmanager
 /// instance or a Grafana-managed Alertmanager (when `isGrafana` is `true`).
-/// In Grafana mode, `grafanaAlertmanagers` lists the per-datasource
-/// Alertmanager names that should be queried via Grafana's proxied API.
+/// In Grafana mode, `grafanaAlertmanager` holds the Grafana datasource UID
+/// of the Alertmanager to query via Grafana's proxied API.
 @Model
 final class Alertmanager {
     /// Stable identifier used as the key for polling timers, notification
@@ -27,14 +27,14 @@ final class Alertmanager {
     var url: String
 
     /// When `true`, the URL points to a Grafana instance and alerts are
-    /// fetched through Grafana's `/api/alertmanager/{name}/api/v2/alerts`
-    /// endpoints for each entry in `grafanaAlertmanagers`.
+    /// fetched through Grafana's `/api/alertmanager/{uid}/api/v2/alerts`
+    /// endpoint using `grafanaAlertmanager`.
     var isGrafana: Bool
 
-    /// Names of the Grafana-managed Alertmanagers to query. Ignored when
-    /// `isGrafana` is `false`. Each fetched alert is tagged with its source
-    /// name to preserve correct silence/dashboard deep-links.
-    var grafanaAlertmanagers: [String]
+    /// Grafana datasource UID of the Alertmanager to query. Ignored when
+    /// `isGrafana` is `false`. Each fetched alert is tagged with this UID
+    /// to preserve correct silence/dashboard deep-links.
+    var grafanaAlertmanager: String
 
     /// Creation timestamp; primarily used for stable ordering as a tiebreaker.
     var timestamp: Date
@@ -87,7 +87,7 @@ final class Alertmanager {
     ///   - url: Base URL of the backend.
     ///   - isGrafana: Whether this entry represents a Grafana-managed
     ///     Alertmanager.
-    ///   - grafanaAlertmanagers: Grafana datasource names to query when
+    ///   - grafanaAlertmanager: Grafana datasource UID to query when
     ///     `isGrafana` is `true`.
     ///   - authType: Authentication strategy applied to outbound requests.
     ///   - timestamp: Creation date used for ordering tiebreaks.
@@ -97,7 +97,7 @@ final class Alertmanager {
         name: String = "",
         url: String = "",
         isGrafana: Bool = false,
-        grafanaAlertmanagers: [String] = [],
+        grafanaAlertmanager: String = "",
         authType: AuthenticationType = .none,
         timestamp: Date = Date(),
         sortOrder: Int = 0
@@ -106,7 +106,7 @@ final class Alertmanager {
         self.name = name
         self.url = url
         self.isGrafana = isGrafana
-        self.grafanaAlertmanagers = grafanaAlertmanagers
+        self.grafanaAlertmanager = grafanaAlertmanager
         self.timestamp = timestamp
         self.sortOrder = sortOrder
         self.authType = authType

--- a/Alertmanager/Services/AlertDeepLinks.swift
+++ b/Alertmanager/Services/AlertDeepLinks.swift
@@ -65,8 +65,8 @@ enum AlertDeepLinks {
     /// - **Grafana**: targets `{url}/alerting/silence/new` with one
     ///   `matcher=key%3Dvalue` query item per label (sorted by key), and an
     ///   `alertmanager=` parameter set to the datasource name.
-    ///   Resolution priority: `resolvedDatasourceName` → `alert.grafanaAlertmanagerSource`
-    ///   → `alertmanager.grafanaAlertmanagers.first` → `""`.
+    ///   Resolution priority: `resolvedDatasourceName` →
+    ///   `alertmanager.grafanaAlertmanager` → `""`.
     /// - **Standard Alertmanager**: targets `{url}/#/silences/new` with a
     ///   single `filter={k1="v1", k2="v2"}` query value, percent-encoded.
     ///
@@ -76,8 +76,7 @@ enum AlertDeepLinks {
     ///   - alert: The alert whose labels are used to populate the silence matchers.
     ///   - alertmanager: The backend the alert was fetched from.
     ///   - resolvedDatasourceName: For Grafana, the human-readable datasource
-    ///     name; when `nil`, falls back through `grafanaAlertmanagerSource`
-    ///     and configured names.
+    ///     name; when `nil`, falls back to the configured datasource UID.
     /// - Returns: The silence URL string.
     static func silenceURL(
         for alert: GettableAlert,
@@ -87,10 +86,11 @@ enum AlertDeepLinks {
         let sortedLabels = alert.labels.sorted { $0.key < $1.key }
 
         if alertmanager.isGrafana {
+            let configuredUID =
+                alertmanager.grafanaAlertmanager.isEmpty ? nil : alertmanager.grafanaAlertmanager
             let alertmanagerName =
                 resolvedDatasourceName
-                ?? alert.grafanaAlertmanagerSource
-                ?? alertmanager.grafanaAlertmanagers.first
+                ?? configuredUID
                 ?? ""
             var matchers: [String] = []
             for (key, value) in sortedLabels {

--- a/Alertmanager/Services/AlertmanagerService.swift
+++ b/Alertmanager/Services/AlertmanagerService.swift
@@ -77,7 +77,7 @@ class AlertmanagerService {
     /// and is returned verbatim without a network call.
     ///
     /// - Parameters:
-    ///   - uid: The UID stored in `grafanaAlertmanagerSource` on an alert.
+    ///   - uid: The Grafana datasource UID to resolve.
     ///   - alertmanager: The Grafana `Alertmanager` configuration supplying
     ///     the base URL and auth credentials.
     /// - Returns: The datasource name if the API call succeeds, or `uid`
@@ -126,44 +126,25 @@ class AlertmanagerService {
 
     /// Fetches alerts through Grafana's proxied Alertmanager API.
     ///
-    /// Iterates over each entry in `alertmanager.grafanaAlertmanagers`,
-    /// querying `GET {url}/api/alertmanager/{name}/api/v2/alerts`. Each
-    /// returned alert is tagged with `grafanaAlertmanagerSource = name`
-    /// so downstream silence/dashboard deep-links know which backend
-    /// produced them. Any failure from any backend is thrown immediately.
+    /// Queries `GET {url}/api/alertmanager/{uid}/api/v2/alerts` using the
+    /// Grafana datasource UID stored in `alertmanager.grafanaAlertmanager`.
     private func fetchGrafanaAlerts(for alertmanager: Alertmanager) async throws -> [GettableAlert]
     {
-        var allAlerts: [GettableAlert] = []
-        var seenFingerprints: Set<String> = []
-
-        for grafanaAlertmanager in alertmanager.grafanaAlertmanagers {
-            let urlString =
-                "\(alertmanager.url)/api/alertmanager/\(grafanaAlertmanager)/api/v2/alerts"
-            guard let url = URL(string: urlString) else {
-                continue
-            }
-
-            var request = URLRequest(url: url)
-            try await configureAuthentication(&request, for: alertmanager)
-
-                var alerts: [GettableAlert] = try await performRequest(request)
-                // Tag each alert with the source backend so downstream
-                // code can build correct silence/dashboard URLs.
-                for i in 0..<alerts.count {
-                    alerts[i].grafanaAlertmanagerSource = grafanaAlertmanager
-                }
-                // Deduplicate by fingerprint across Grafana backends — the same
-                // alert can be federated to multiple alertmanagers and would
-                // otherwise appear multiple times with the same ID, causing
-                // undefined SwiftUI ForEach behaviour.
-                for alert in alerts {
-                    if seenFingerprints.insert(alert.fingerprint).inserted {
-                        allAlerts.append(alert)
-                    }
-                }
+        let grafanaAlertmanager = alertmanager.grafanaAlertmanager
+        guard !grafanaAlertmanager.isEmpty else {
+            return []
         }
 
-        return allAlerts
+        let urlString =
+            "\(alertmanager.url)/api/alertmanager/\(grafanaAlertmanager)/api/v2/alerts"
+        guard let url = URL(string: urlString) else {
+            throw AlertmanagerError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        try await configureAuthentication(&request, for: alertmanager)
+
+        return try await performRequest(request)
     }
 
     /// Generic request executor.

--- a/Alertmanager/Services/ImportExportManager.swift
+++ b/Alertmanager/Services/ImportExportManager.swift
@@ -41,7 +41,7 @@ struct ExportAlertmanager: Codable {
     let name: String
     let url: String
     let isGrafana: Bool
-    let grafanaAlertmanagers: [String]
+    let grafanaAlertmanager: String
     let authType: ExportAuthType
     let sortOrder: Int?
 }
@@ -164,7 +164,7 @@ class ImportExportManager {
                 name: alertmanager.name,
                 url: alertmanager.url,
                 isGrafana: alertmanager.isGrafana,
-                grafanaAlertmanagers: alertmanager.grafanaAlertmanagers,
+                grafanaAlertmanager: alertmanager.grafanaAlertmanager,
                 authType: convertAuthType(alertmanager.authType),
                 sortOrder: alertmanager.sortOrder
             )
@@ -265,7 +265,7 @@ class ImportExportManager {
                     name: exportAlertmanager.name,
                     url: exportAlertmanager.url,
                     isGrafana: exportAlertmanager.isGrafana,
-                    grafanaAlertmanagers: exportAlertmanager.grafanaAlertmanagers,
+                    grafanaAlertmanager: exportAlertmanager.grafanaAlertmanager,
                     authType: convertToAuthType(exportAlertmanager.authType)
                 )
                 alertmanager.sortOrder = exportAlertmanager.sortOrder ?? 0

--- a/Alertmanager/Services/NotificationService.swift
+++ b/Alertmanager/Services/NotificationService.swift
@@ -327,11 +327,10 @@ class NotificationService: NSObject {
             // For Grafana backends, resolve the datasource name from its UID
             // first (unless the UID is already the built-in "grafana" value).
             if let alertmanager {
+                let configuredUID =
+                    alertmanager.grafanaAlertmanager.isEmpty ? nil : alertmanager.grafanaAlertmanager
                 let resolvedName: String?
-                if alertmanager.isGrafana,
-                    let uid = alert.grafanaAlertmanagerSource ?? alertmanager.grafanaAlertmanagers.first,
-                    uid != "grafana"
-                {
+                if alertmanager.isGrafana, let uid = configuredUID, uid != "grafana" {
                     resolvedName = await service.fetchDatasourceName(for: uid, in: alertmanager)
                 } else {
                     resolvedName = nil
@@ -392,11 +391,9 @@ class NotificationService: NSObject {
 
     /// Finds the alertmanager that produced `alert`.
     ///
-    /// For Grafana alerts the `grafanaAlertmanagerSource` tag is used to
-    /// confirm a match. For standard alerts any alertmanager whose cached
-    /// list contains the fingerprint is accepted. Falls back to `nil` if
-    /// nothing can be resolved (e.g. alert arrived very recently and the
-    /// cache hasn't settled).
+    /// Any alertmanager whose cached list contains the fingerprint is
+    /// accepted. Falls back to `nil` if nothing can be resolved (e.g.
+    /// alert arrived very recently and the cache hasn't settled).
     private func resolveAlertmanager(
         for alert: GettableAlert, in alertmanagers: [Alertmanager]
     ) -> Alertmanager? {

--- a/Alertmanager/Views/AlertRowView.swift
+++ b/Alertmanager/Views/AlertRowView.swift
@@ -403,27 +403,23 @@ struct AlertRowView: View {
     /// - **Grafana**: targets `{url}/alerting/silence/new` with one
     ///   `matcher=key%3Dvalue` query item per label, and an
     ///   `alertmanager=` parameter set to the datasource *name*. When the
-    ///   alert's `grafanaAlertmanagerSource` is not `"grafana"`, the name is
-    ///   resolved via `GET {url}/api/datasources/uid/{uid}` because Grafana
-    ///   expects the human-readable name rather than the datasource UID.
+    ///   resolved UID is not `"grafana"`, the name is resolved via
+    ///   `GET {url}/api/datasources/uid/{uid}` because Grafana expects the
+    ///   human-readable name rather than the datasource UID.
     /// - **Standard Alertmanager**: targets `{url}/#/silences/new` with a
     ///   single `filter={k1="v1", k2="v2"}` query value, percent-encoded.
     private func openSilenceURL() async {
+        let configuredUID =
+            alertmanager.grafanaAlertmanager.isEmpty ? nil : alertmanager.grafanaAlertmanager
         let resolvedName: String?
-        if alertmanager.isGrafana,
-            let uid = alert.grafanaAlertmanagerSource ?? alertmanager.grafanaAlertmanagers.first,
-            uid != "grafana"
-        {
+        if alertmanager.isGrafana, let uid = configuredUID, uid != "grafana" {
             let service = AlertmanagerService()
             resolvedName = await service.fetchDatasourceName(for: uid, in: alertmanager)
         } else {
             resolvedName = nil
         }
 
-        if alertmanager.isGrafana,
-            alert.grafanaAlertmanagerSource == nil,
-            alertmanager.grafanaAlertmanagers.isEmpty
-        {
+        if alertmanager.isGrafana, configuredUID == nil {
             print("No Grafana alertmanager configured")
             return
         }
@@ -466,7 +462,7 @@ struct AlertRowView: View {
         name: "Test Alertmanager",
         url: "https://alertmanager.example.com",
         isGrafana: false,
-        grafanaAlertmanagers: [],
+        grafanaAlertmanager: "",
         authType: .none
     )
 

--- a/Alertmanager/Views/AlertmanagerDetailView.swift
+++ b/Alertmanager/Views/AlertmanagerDetailView.swift
@@ -221,7 +221,7 @@ struct AlertmanagerDetailView: View {
         name: "Test Alertmanager",
         url: "https://alertmanager.example.com",
         isGrafana: true,
-        grafanaAlertmanagers: ["grafana", "alertmanager"],
+        grafanaAlertmanager: "grafana",
         authType: .basicAuth(username: "admin", password: "secret")
     )
     container.mainContext.insert(alertmanager)

--- a/Alertmanager/Views/AlertmanagerFormView.swift
+++ b/Alertmanager/Views/AlertmanagerFormView.swift
@@ -34,10 +34,8 @@ struct AlertmanagerFormView: View {
     @State private var url: String = ""
     /// Whether this entry targets a Grafana-managed Alertmanager.
     @State private var isGrafana: Bool = false
-    /// Grafana datasource names to query (Grafana mode only).
-    @State private var grafanaAlertmanagers: [String] = []
-    /// Working buffer for the "add Grafana alertmanager" text field.
-    @State private var newGrafanaAlertmanager: String = ""
+    /// Grafana datasource UID to query (Grafana mode only).
+    @State private var grafanaAlertmanager: String = ""
     /// Currently selected high-level auth strategy.
     @State private var selectedAuthType: AuthTypeOption = .none
     /// Basic-auth username (used when `selectedAuthType == .basicAuth`).
@@ -80,7 +78,7 @@ struct AlertmanagerFormView: View {
             _name = State(initialValue: alertmanager.name)
             _url = State(initialValue: alertmanager.url)
             _isGrafana = State(initialValue: alertmanager.isGrafana)
-            _grafanaAlertmanagers = State(initialValue: alertmanager.grafanaAlertmanagers)
+            _grafanaAlertmanager = State(initialValue: alertmanager.grafanaAlertmanager)
 
             // Decompose the persisted enum-with-associated-values into the
             // flat UI selectors plus their corresponding text fields.
@@ -121,41 +119,11 @@ struct AlertmanagerFormView: View {
 
                 Toggle("Is Grafana", isOn: $isGrafana)
                     .accessibilityIdentifier("alertmanager-is-grafana-toggle")
-            }
 
-            // Grafana-only section: editable list of datasource names. Each
-            // row has a remove button; the trailing row appends a new entry.
-            if isGrafana {
-                Section("Grafana Alertmanagers") {
-                    ForEach(grafanaAlertmanagers, id: \.self) { alertmanager in
-                        HStack {
-                            Text(alertmanager)
-                            Spacer()
-                            Button(action: {
-                                grafanaAlertmanagers.removeAll { $0 == alertmanager }
-                            }) {
-                                Image(systemName: "minus.circle.fill")
-                                    .foregroundColor(.red)
-                            }
-                            .buttonStyle(.plain)
-                        }
-                    }
-
-                    HStack {
-                        TextField("Alertmanager Name", text: $newGrafanaAlertmanager)
-                            .textFieldStyle(.roundedBorder)
-                        Button(action: {
-                            if !newGrafanaAlertmanager.isEmpty {
-                                grafanaAlertmanagers.append(newGrafanaAlertmanager)
-                                newGrafanaAlertmanager = ""
-                            }
-                        }) {
-                            Image(systemName: "plus.circle.fill")
-                                .foregroundColor(.green)
-                        }
-                        .buttonStyle(.plain)
-                        .disabled(newGrafanaAlertmanager.isEmpty)
-                    }
+                if isGrafana {
+                    TextField("Grafana Alertmanager", text: $grafanaAlertmanager)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityIdentifier("alertmanager-grafana-datasource-id-field")
                 }
             }
 
@@ -299,7 +267,7 @@ struct AlertmanagerFormView: View {
             alertmanager.name = name
             alertmanager.url = url
             alertmanager.isGrafana = isGrafana
-            alertmanager.grafanaAlertmanagers = grafanaAlertmanagers
+            alertmanager.grafanaAlertmanager = grafanaAlertmanager
             alertmanager.authType = authType
 
             // Restart polling so URL/auth changes take effect immediately.
@@ -314,7 +282,7 @@ struct AlertmanagerFormView: View {
                 name: name,
                 url: url,
                 isGrafana: isGrafana,
-                grafanaAlertmanagers: grafanaAlertmanagers,
+                grafanaAlertmanager: grafanaAlertmanager,
                 authType: authType,
                 sortOrder: maxSortOrder + 1
             )

--- a/AlertmanagerTests/AlertDeepLinksTests.swift
+++ b/AlertmanagerTests/AlertDeepLinksTests.swift
@@ -13,22 +13,21 @@ import Testing
 private func makeAlertmanager(
     url: String,
     isGrafana: Bool = false,
-    grafanaAlertmanagers: [String] = []
+    grafanaAlertmanager: String = ""
 ) -> Alertmanager {
     Alertmanager(
         name: "Test",
         url: url,
         isGrafana: isGrafana,
-        grafanaAlertmanagers: grafanaAlertmanagers
+        grafanaAlertmanager: grafanaAlertmanager
     )
 }
 
 private func makeAlert(
     labels: [String: String] = [:],
-    grafanaAlertmanagerSource: String? = nil,
     generatorURL: String? = nil
 ) -> GettableAlert {
-    var a = GettableAlert(
+    GettableAlert(
         annotations: [:],
         receivers: [],
         fingerprint: "fp",
@@ -39,8 +38,6 @@ private func makeAlert(
         labels: labels,
         generatorURL: generatorURL
     )
-    a.grafanaAlertmanagerSource = grafanaAlertmanagerSource
-    return a
 }
 
 // MARK: - AlertDeepLinks.sanitize
@@ -162,7 +159,7 @@ struct AlertDeepLinksSilenceGrafanaTests {
 
     @Test("Uses /alerting/silence/new path")
     func grafanaSilencePath() {
-        let am = makeAlertmanager(url: "https://grafana.example.com", isGrafana: true, grafanaAlertmanagers: ["mimir"])
+        let am = makeAlertmanager(url: "https://grafana.example.com", isGrafana: true, grafanaAlertmanager: "mimir")
         let alert = makeAlert(labels: ["severity": "critical"])
         let url = AlertDeepLinks.silenceURL(for: alert, alertmanager: am)
         #expect(url.contains("/alerting/silence/new"))
@@ -170,39 +167,31 @@ struct AlertDeepLinksSilenceGrafanaTests {
 
     @Test("alertmanager parameter uses resolvedDatasourceName when provided")
     func usesResolvedName() {
-        let am = makeAlertmanager(url: "https://grafana.example.com", isGrafana: true, grafanaAlertmanagers: ["uid-123"])
+        let am = makeAlertmanager(url: "https://grafana.example.com", isGrafana: true, grafanaAlertmanager: "uid-123")
         let alert = makeAlert(labels: [:])
         let url = AlertDeepLinks.silenceURL(for: alert, alertmanager: am, resolvedDatasourceName: "MyMimir")
         #expect(url.contains("alertmanager=MyMimir"))
     }
 
-    @Test("alertmanager falls back to grafanaAlertmanagerSource when resolvedName is nil")
-    func fallsToSource() {
-        let am = makeAlertmanager(url: "https://grafana.example.com", isGrafana: true, grafanaAlertmanagers: [])
-        let alert = makeAlert(labels: [:], grafanaAlertmanagerSource: "from-source")
-        let url = AlertDeepLinks.silenceURL(for: alert, alertmanager: am, resolvedDatasourceName: nil)
-        #expect(url.contains("alertmanager=from-source"))
-    }
-
-    @Test("alertmanager falls back to grafanaAlertmanagers.first when both other sources are nil")
-    func fallsToFirst() {
-        let am = makeAlertmanager(url: "https://grafana.example.com", isGrafana: true, grafanaAlertmanagers: ["fallback-am"])
-        let alert = makeAlert(labels: [:], grafanaAlertmanagerSource: nil)
+    @Test("alertmanager falls back to grafanaAlertmanager when resolvedName is nil")
+    func fallsToConfigured() {
+        let am = makeAlertmanager(url: "https://grafana.example.com", isGrafana: true, grafanaAlertmanager: "fallback-am")
+        let alert = makeAlert(labels: [:])
         let url = AlertDeepLinks.silenceURL(for: alert, alertmanager: am, resolvedDatasourceName: nil)
         #expect(url.contains("alertmanager=fallback-am"))
     }
 
     @Test("alertmanager falls back to empty string when all sources are nil/empty")
     func fallsToEmpty() {
-        let am = makeAlertmanager(url: "https://grafana.example.com", isGrafana: true, grafanaAlertmanagers: [])
-        let alert = makeAlert(labels: [:], grafanaAlertmanagerSource: nil)
+        let am = makeAlertmanager(url: "https://grafana.example.com", isGrafana: true, grafanaAlertmanager: "")
+        let alert = makeAlert(labels: [:])
         let url = AlertDeepLinks.silenceURL(for: alert, alertmanager: am, resolvedDatasourceName: nil)
         #expect(url.contains("alertmanager=&") || url.hasSuffix("alertmanager="))
     }
 
     @Test("Each label becomes matcher=key%3Dvalue")
     func matcherFormat() {
-        let am = makeAlertmanager(url: "https://grafana.example.com", isGrafana: true, grafanaAlertmanagers: ["am"])
+        let am = makeAlertmanager(url: "https://grafana.example.com", isGrafana: true, grafanaAlertmanager: "am")
         let alert = makeAlert(labels: ["severity": "critical"])
         let url = AlertDeepLinks.silenceURL(for: alert, alertmanager: am)
         #expect(url.contains("matcher=severity%3Dcritical"))
@@ -210,7 +199,7 @@ struct AlertDeepLinksSilenceGrafanaTests {
 
     @Test("Label values with special chars are percent-encoded in Grafana URL")
     func grafanaSpecialCharsEncoded() {
-        let am = makeAlertmanager(url: "https://grafana.example.com", isGrafana: true, grafanaAlertmanagers: ["am"])
+        let am = makeAlertmanager(url: "https://grafana.example.com", isGrafana: true, grafanaAlertmanager: "am")
         // Use a space — spaces are NOT in urlQueryAllowed and must be encoded
         let alert = makeAlert(labels: ["k": "value with spaces"])
         let url = AlertDeepLinks.silenceURL(for: alert, alertmanager: am)
@@ -219,7 +208,7 @@ struct AlertDeepLinksSilenceGrafanaTests {
 
     @Test("Labels are sorted by key")
     func grafanaLabelsSorted() {
-        let am = makeAlertmanager(url: "https://grafana.example.com", isGrafana: true, grafanaAlertmanagers: ["am"])
+        let am = makeAlertmanager(url: "https://grafana.example.com", isGrafana: true, grafanaAlertmanager: "am")
         let alert = makeAlert(labels: ["z_key": "z", "a_key": "a"])
         let url = AlertDeepLinks.silenceURL(for: alert, alertmanager: am)
         let aPos = url.range(of: "a_key")!.lowerBound

--- a/AlertmanagerTests/AlertmanagerModelTests.swift
+++ b/AlertmanagerTests/AlertmanagerModelTests.swift
@@ -182,7 +182,7 @@ struct FilterLabelMatchersTests {
 @Suite("Alertmanager model properties")
 struct AlertmanagerModelPropertyTests {
 
-    @Test("sortOrder, isGrafana, grafanaAlertmanagers persist correctly")
+    @Test("sortOrder, isGrafana, grafanaAlertmanager persist correctly")
     @MainActor
     func propertiesPersist() throws {
         let container = try makeInMemoryContainer()
@@ -192,7 +192,7 @@ struct AlertmanagerModelPropertyTests {
             name: "Grafana",
             url: "https://grafana.example.com",
             isGrafana: true,
-            grafanaAlertmanagers: ["mimir-am", "loki-am"],
+            grafanaAlertmanager: "mimir-am",
             sortOrder: 5
         )
         context.insert(am)
@@ -203,7 +203,7 @@ struct AlertmanagerModelPropertyTests {
         #expect(result.name == "Grafana")
         #expect(result.url == "https://grafana.example.com")
         #expect(result.isGrafana == true)
-        #expect(result.grafanaAlertmanagers == ["mimir-am", "loki-am"])
+        #expect(result.grafanaAlertmanager == "mimir-am")
         #expect(result.sortOrder == 5)
     }
 }

--- a/AlertmanagerTests/ImportExportManagerTests.swift
+++ b/AlertmanagerTests/ImportExportManagerTests.swift
@@ -298,7 +298,7 @@ struct ImportExportRoundTripTests {
         let exportJSON = """
         {
             "alertmanagers": [
-                {"name": "A", "url": "http://a.example.com", "isGrafana": false, "grafanaAlertmanagers": [], "authType": {"type": "none"}}
+                {"name": "A", "url": "http://a.example.com", "isGrafana": false, "grafanaAlertmanager": "", "authType": {"type": "none"}}
             ],
             "filters": [
                 {"name": "F", "alertmanagerNames": [], "states": [], "receivers": [], "labelMatchers": []}

--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ rm .bundle; xcodebuild -project Alertmanager.xcodeproj -scheme Alertmanager -con
 xcode-build-server config -project Alertmanager.xcodeproj -scheme Alertmanager
 ```
 
+### App crashes on launch after upgrade (SwiftData schema mismatch)
+
+If the app crashes immediately on launch with a
+`Failed to create ModelContainer` error after upgrading, the on-disk SwiftData
+store was written by an older version whose schema is incompatible with the
+current one. The app does not migrate existing data automatically — delete the
+store and relaunch to start from a clean slate.
+
+```bash
+rm -rf ~/Library/Application\ Support/de.ricoberger.Alertmanager
+```
+
 ### Notification opens a new (empty) window
 
 If tapping a notification opens a fresh empty window while the alert is


### PR DESCRIPTION
Instead of adding multiple Grafana Alertmanager instances to an
Alertmanger configuration, we will now only allow one Grafana
Alertmanager instance per Alertmanager configuration.
