### PR TITLE
feat(alert-row): copy alert as markdown via hover button

### DIFF
--- a/Alertmanager/Services/AlertMarkdown.swift
+++ b/Alertmanager/Services/AlertMarkdown.swift
@@ -1,0 +1,115 @@
+//
+//  AlertMarkdown.swift
+//  Alertmanager
+//
+
+import Foundation
+
+/// Pure, stateless namespace for serialising an alert as a markdown snippet
+/// suitable for pasting into chat, issue trackers, or runbooks.
+///
+/// The returned string always carries enough context for a reader to
+/// reproduce a query against the originating Alertmanager: the backend's
+/// base URL, the resolved authentication credentials (when supplied), the
+/// alert's identifying labels, and the description/annotations.
+///
+/// All formatting is deterministic — labels and annotations are sorted by
+/// key — so tests can compare snapshots without flake.
+enum AlertMarkdown {
+
+    /// Builds a markdown representation of `alert` for the given
+    /// `alertmanager`.
+    ///
+    /// - Parameters:
+    ///   - alert: The alert payload as returned by the Alertmanager API.
+    ///   - alertmanager: The backend the alert was fetched from. Its `url`
+    ///     is rendered into the output so the recipient knows which
+    ///     instance the alert came from.
+    ///   - authCredentials: Optional pre-resolved credentials string (e.g.
+    ///     `"Basic user:pass"` or `"Bearer …"`). When `nil`, no credentials
+    ///     line is emitted. Resolution is the caller's responsibility
+    ///     because token sources may require asynchronous I/O.
+    /// - Returns: A markdown string with a heading, metadata bullets, and
+    ///   optional summary heading + description body, `Labels`, and
+    ///   `Annotations` sections.
+    static func build(
+        for alert: GettableAlert,
+        alertmanager: Alertmanager,
+        authCredentials: String? = nil
+    ) -> String {
+        var lines: [String] = []
+
+        lines.append("# \(alert.alertName)")
+        lines.append("")
+
+        if alertmanager.isGrafana {
+            lines.append("- **Grafana URL:** \(alertmanager.url)")
+        } else {
+            lines.append("- **Alertmanager URL:** \(alertmanager.url)")
+        }
+        if let credentials = authCredentials, !credentials.isEmpty {
+            if alertmanager.isGrafana {
+                lines.append("- **Grafana Credentials:** \(credentials)")
+            } else {
+                lines.append("- **Alertmanager Credentials:** \(credentials)")
+            }
+        }
+        if alertmanager.isGrafana, !alertmanager.grafanaAlertmanager.isEmpty {
+            lines.append(
+                "- **Grafana Alertmanager Datasource:** \(alertmanager.grafanaAlertmanager)")
+        }
+        lines.append("- **Severity:** \(alert.severity)")
+        lines.append("- **State:** \(alert.status.state.rawValue.capitalized)")
+        lines.append(
+            "- **Started:** \(alert.startsAt.formatted(date: .abbreviated, time: .shortened))")
+        if !alert.receivers.isEmpty {
+            let names = alert.receivers.map { $0.name }.joined(separator: ", ")
+            lines.append("- **Receivers:** \(names)")
+        }
+        if let generatorURL = alert.generatorURL, !generatorURL.isEmpty {
+            lines.append("- **Source:** \(generatorURL)")
+        }
+
+        let summary = alert.summary?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let description = alert.description?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // `summary` and `description` are surfaced as their own sections
+        // above the generic Annotations list, so the generic list skips
+        // both to avoid duplication.
+        if let summary, !summary.isEmpty {
+            lines.append("")
+            lines.append("## Summary")
+            lines.append("")
+            lines.append(summary)
+        }
+        if let description, !description.isEmpty {
+            lines.append("")
+            lines.append("## Description")
+            lines.append("")
+            lines.append(description)
+        }
+
+        if !alert.labels.isEmpty {
+            lines.append("")
+            lines.append("## Labels")
+            lines.append("")
+            for (key, value) in alert.labels.sorted(by: { $0.key < $1.key }) {
+                lines.append("- `\(key)`: `\(value)`")
+            }
+        }
+
+        let remainingAnnotations = alert.annotations.filter { key, _ in
+            key != "description" && key != "summary"
+        }
+        if !remainingAnnotations.isEmpty {
+            lines.append("")
+            lines.append("## Annotations")
+            lines.append("")
+            for (key, value) in remainingAnnotations.sorted(by: { $0.key < $1.key }) {
+                lines.append("- `\(key)`: `\(value)`")
+            }
+        }
+
+        return lines.joined(separator: "\n")
+    }
+}

--- a/Alertmanager/Services/AlertmanagerService.swift
+++ b/Alertmanager/Services/AlertmanagerService.swift
@@ -107,6 +107,38 @@ class AlertmanagerService {
         }
     }
 
+    // MARK: - Public Methods (Auth credentials)
+
+    /// Resolves the configured authentication into a human-readable
+    /// credentials string suitable for pasting into a markdown export.
+    ///
+    /// Token sources (`.file` / `.command`) are resolved live, so the
+    /// returned value reflects whatever the source produces right now —
+    /// rotated or short-lived tokens included.
+    ///
+    /// - `.none`: returns `nil`.
+    /// - `.basicAuth(user, pass)`: returns `"Basic <user>:<pass>"`.
+    /// - `.tokenAuth(source)`: returns `"Bearer <token>"`, or `nil` if the
+    ///   token cannot be resolved (resolution failures are logged).
+    func resolveAuthCredentials(for alertmanager: Alertmanager) async -> String? {
+        switch alertmanager.authType {
+        case .none:
+            return nil
+
+        case .basicAuth(let username, let password):
+            return "Basic \(username):\(password)"
+
+        case .tokenAuth(let tokenSource):
+            do {
+                let token = try await retrieveToken(from: tokenSource)
+                return "Bearer \(token)"
+            } catch {
+                print("resolveAuthCredentials: token resolution failed: \(error)")
+                return nil
+            }
+        }
+    }
+
     // MARK: - Private Methods
 
     /// Fetches alerts from a standard Prometheus Alertmanager via

--- a/Alertmanager/Views/AlertRowView.swift
+++ b/Alertmanager/Views/AlertRowView.swift
@@ -45,54 +45,84 @@ struct AlertRowView: View {
     /// in flight. Used to disable the Silence button during the async fetch.
     @State private var isFetchingSilenceURL: Bool = false
 
+    /// `true` while the cursor is over the row title; controls visibility of
+    /// the hover-revealed "copy as markdown" icon next to the alert name.
+    @State private var isHoveringTitle: Bool = false
+
+    /// Briefly `true` after a successful copy. Flips the copy icon to a
+    /// checkmark for a moment as confirmation feedback.
+    @State private var didCopy: Bool = false
+
     /// User-configured label badge mappings, observed from `SettingsManager`.
     @ObservedObject private var settings = SettingsManager.shared
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Collapsed header: tap anywhere on the row to toggle expansion.
-            Button(action: {
+            // Implemented with `onTapGesture` rather than wrapping in a
+            // Button so the nested copy Button below stays the sole hit
+            // target inside its own bounds (nested SwiftUI Buttons fight
+            // for clicks).
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 6) {
+                        Text(
+                            settings.showAlertmanagerName
+                                ? "[\(alertmanagerDisplayName)] \(alert.alertName)"
+                                : alert.alertName
+                        )
+                        .font(.headline)
+                        .foregroundColor(.primary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+
+                        Button(action: {
+                            Task { await copyAlertAsMarkdown() }
+                        }) {
+                            Image(systemName: didCopy ? "checkmark" : "doc.on.doc")
+                                .font(.system(size: 11))
+                                .foregroundColor(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                        .opacity(isHoveringTitle || didCopy ? 1 : 0)
+                        .help("Copy alert as Markdown")
+                        .accessibilityLabel("Copy alert as Markdown")
+                        .accessibilityIdentifier("alert-row-copy")
+                    }
+                    .onHover { isHoveringTitle = $0 }
+
+                    if let subtitle = alert.subtitle {
+                        Text(subtitle)
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                            .lineLimit(isExpandedState ? nil : 1)
+                    }
+                }
+
+                Spacer()
+
+                HStack(spacing: 4) {
+                    timeBadge
+                    severityBadge
+                    ForEach(customLabelBadges, id: \.0) { key, value, color in
+                        Text(value.uppercased())
+                            .font(.caption)
+                            .fontWeight(.bold)
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(color)
+                            .cornerRadius(4)
+                    }
+                }
+            }
+            .padding()
+            .contentShape(Rectangle())
+            .onTapGesture {
                 withAnimation {
                     isExpandedState.toggle()
                 }
-            }) {
-                HStack(alignment: .top, spacing: 12) {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(settings.showAlertmanagerName ? "[\(alertmanagerDisplayName)] \(alert.alertName)" : alert.alertName)
-                            .font(.headline)
-                            .foregroundColor(.primary)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-
-                        if let subtitle = alert.subtitle {
-                            Text(subtitle)
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
-                                .lineLimit(isExpandedState ? nil : 1)
-                        }
-                    }
-
-                    Spacer()
-
-                    HStack(spacing: 4) {
-                        timeBadge
-                        severityBadge
-                        ForEach(customLabelBadges, id: \.0) { key, value, color in
-                            Text(value.uppercased())
-                                .font(.caption)
-                                .fontWeight(.bold)
-                                .foregroundColor(.white)
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 4)
-                                .background(color)
-                                .cornerRadius(4)
-                        }
-                    }
-                }
-                .padding()
-                .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
 
             if isExpandedState {
                 // Expanded body: state/receivers/start, optional description,
@@ -139,7 +169,9 @@ struct AlertRowView: View {
                     }
                     .padding(.horizontal)
 
-                    if let description = alert.description.map({ $0.trimmingCharacters(in: .newlines) }), !description.isEmpty {
+                    if let description = alert.description.map({
+                        $0.trimmingCharacters(in: .newlines)
+                    }), !description.isEmpty {
                         VStack(alignment: .leading, spacing: 4) {
                             Text("Description")
                                 .font(.caption)
@@ -388,7 +420,7 @@ struct AlertRowView: View {
     private func openURL(_ urlString: String) {
         print("Original URL string: \(urlString)")
         guard let sanitized = AlertDeepLinks.sanitize(urlString),
-              let finalURL = URL(string: sanitized)
+            let finalURL = URL(string: sanitized)
         else {
             print("Failed to parse or construct URL")
             return
@@ -435,7 +467,8 @@ struct AlertRowView: View {
 
     /// Opens the Grafana dashboard referenced by `__dashboardUid__`.
     private func openDashboardURL(_ dashboardUID: String) {
-        let urlString = AlertDeepLinks.dashboardURL(alertmanager: alertmanager, dashboardUID: dashboardUID)
+        let urlString = AlertDeepLinks.dashboardURL(
+            alertmanager: alertmanager, dashboardUID: dashboardUID)
         print("Opening Grafana dashboard URL: \(urlString)")
         if let url = URL(string: urlString) {
             NSWorkspace.shared.open(url)
@@ -444,10 +477,35 @@ struct AlertRowView: View {
         }
     }
 
+    /// Resolves the alertmanager's auth credentials, renders the alert as
+    /// markdown, and writes the result to the general pasteboard.
+    ///
+    /// The markdown includes the alertmanager base URL and the resolved
+    /// credentials so the recipient can reproduce the underlying API call.
+    /// On success, the copy icon briefly switches to a checkmark.
+    private func copyAlertAsMarkdown() async {
+        let service = AlertmanagerService()
+        let credentials = await service.resolveAuthCredentials(for: alertmanager)
+        let markdown = AlertMarkdown.build(
+            for: alert,
+            alertmanager: alertmanager,
+            authCredentials: credentials
+        )
+
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(markdown, forType: .string)
+
+        didCopy = true
+        try? await Task.sleep(nanoseconds: 1_500_000_000)
+        didCopy = false
+    }
+
     /// Opens a specific Grafana panel using `__dashboardUid__` and
     /// `__panelId__` annotations.
     private func openPanelURL(dashboardUID: String, panelId: String) {
-        let urlString = AlertDeepLinks.panelURL(alertmanager: alertmanager, dashboardUID: dashboardUID, panelId: panelId)
+        let urlString = AlertDeepLinks.panelURL(
+            alertmanager: alertmanager, dashboardUID: dashboardUID, panelId: panelId)
         print("Opening Grafana panel URL: \(urlString)")
         if let url = URL(string: urlString) {
             NSWorkspace.shared.open(url)

--- a/AlertmanagerTests/AlertMarkdownTests.swift
+++ b/AlertmanagerTests/AlertMarkdownTests.swift
@@ -1,0 +1,347 @@
+//
+//  AlertMarkdownTests.swift
+//  AlertmanagerTests
+//
+
+import Foundation
+import Testing
+
+@testable import Alertmanager
+
+// MARK: - Helpers
+
+private func makeAlertmanager(
+    url: String = "https://am.example.com",
+    isGrafana: Bool = false,
+    grafanaAlertmanager: String = ""
+) -> Alertmanager {
+    Alertmanager(
+        name: "Test",
+        url: url,
+        isGrafana: isGrafana,
+        grafanaAlertmanager: grafanaAlertmanager
+    )
+}
+
+private func makeAlert(
+    labels: [String: String] = [:],
+    annotations: [String: String] = [:],
+    receivers: [String] = [],
+    generatorURL: String? = nil,
+    state: AlertState = .active
+) -> GettableAlert {
+    GettableAlert(
+        annotations: annotations,
+        receivers: receivers.map { Receiver(name: $0) },
+        fingerprint: "fp",
+        startsAt: Date(timeIntervalSince1970: 1_700_000_000),
+        updatedAt: Date(timeIntervalSince1970: 1_700_000_000),
+        endsAt: Date(timeIntervalSince1970: 1_700_003_600),
+        status: AlertStatus(state: state, silencedBy: [], inhibitedBy: []),
+        labels: labels,
+        generatorURL: generatorURL
+    )
+}
+
+// MARK: - AlertMarkdown.build
+
+@Suite("AlertMarkdown.build")
+struct AlertMarkdownBuildTests {
+
+    @Test("Includes alert name as top-level heading")
+    func alertNameHeading() {
+        let md = AlertMarkdown.build(
+            for: makeAlert(labels: ["alertname": "HighCPU", "severity": "warning"]),
+            alertmanager: makeAlertmanager()
+        )
+        #expect(md.hasPrefix("# HighCPU"))
+    }
+
+    @Test("Falls back to UnknownAlert when alertname label is missing")
+    func missingAlertname() {
+        let md = AlertMarkdown.build(
+            for: makeAlert(labels: ["severity": "info"]),
+            alertmanager: makeAlertmanager()
+        )
+        #expect(md.contains("# UnknownAlert"))
+    }
+
+    @Test("Renders severity, state, and alertmanager URL")
+    func coreMetadata() {
+        let md = AlertMarkdown.build(
+            for: makeAlert(
+                labels: ["alertname": "Disk", "severity": "critical"],
+                state: .suppressed
+            ),
+            alertmanager: makeAlertmanager(url: "https://am.example.com")
+        )
+        #expect(md.contains("**Severity:** critical"))
+        #expect(md.contains("**State:** Suppressed"))
+        #expect(md.contains("**Alertmanager URL:** https://am.example.com"))
+    }
+
+    @Test("Renames URL field to Grafana URL and adds datasource for Grafana backends")
+    func grafanaURLAndDatasource() {
+        let md = AlertMarkdown.build(
+            for: makeAlert(labels: ["alertname": "X", "severity": "warning"]),
+            alertmanager: makeAlertmanager(
+                url: "https://grafana.example.com",
+                isGrafana: true,
+                grafanaAlertmanager: "mimir-prod"
+            )
+        )
+        #expect(md.contains("**Grafana URL:** https://grafana.example.com"))
+        #expect(md.contains("**Grafana Alertmanager Datasource:** mimir-prod"))
+        #expect(!md.contains("**Alertmanager URL:**"))
+    }
+
+    @Test("Omits datasource line for Grafana backends with no configured datasource")
+    func grafanaWithoutDatasource() {
+        let md = AlertMarkdown.build(
+            for: makeAlert(labels: ["alertname": "X", "severity": "warning"]),
+            alertmanager: makeAlertmanager(
+                url: "https://grafana.example.com",
+                isGrafana: true,
+                grafanaAlertmanager: ""
+            )
+        )
+        #expect(md.contains("**Grafana URL:** https://grafana.example.com"))
+        #expect(!md.contains("**Grafana Alertmanager Datasource:**"))
+    }
+
+    @Test("Grafana credentials line uses Grafana-specific label")
+    func grafanaCredentialsLabel() {
+        let md = AlertMarkdown.build(
+            for: makeAlert(labels: ["alertname": "X", "severity": "warning"]),
+            alertmanager: makeAlertmanager(
+                url: "https://grafana.example.com",
+                isGrafana: true,
+                grafanaAlertmanager: "mimir-prod"
+            ),
+            authCredentials: "Bearer abc"
+        )
+        #expect(md.contains("**Grafana Credentials:** Bearer abc"))
+        #expect(!md.contains("**Alertmanager Credentials:**"))
+    }
+
+    @Test("Standard Alertmanager backends do not get a Datasource line")
+    func standardBackendNoDatasource() {
+        let md = AlertMarkdown.build(
+            for: makeAlert(labels: ["alertname": "X", "severity": "warning"]),
+            alertmanager: makeAlertmanager(url: "https://am.example.com")
+        )
+        #expect(md.contains("**Alertmanager URL:** https://am.example.com"))
+        #expect(!md.contains("**Grafana URL:**"))
+        #expect(!md.contains("**Grafana Alertmanager Datasource:**"))
+    }
+
+    @Test("Includes credentials line when supplied")
+    func includesCredentials() {
+        let md = AlertMarkdown.build(
+            for: makeAlert(labels: ["alertname": "X", "severity": "warning"]),
+            alertmanager: makeAlertmanager(),
+            authCredentials: "Basic alice:secret"
+        )
+        #expect(md.contains("**Alertmanager Credentials:** Basic alice:secret"))
+    }
+
+    @Test("Omits credentials line when nil")
+    func omitsCredentialsWhenNil() {
+        let md = AlertMarkdown.build(
+            for: makeAlert(labels: ["alertname": "X", "severity": "warning"]),
+            alertmanager: makeAlertmanager(),
+            authCredentials: nil
+        )
+        #expect(!md.contains("Credentials:"))
+    }
+
+    @Test("Omits credentials line when empty string")
+    func omitsCredentialsWhenEmpty() {
+        let md = AlertMarkdown.build(
+            for: makeAlert(labels: ["alertname": "X", "severity": "warning"]),
+            alertmanager: makeAlertmanager(),
+            authCredentials: ""
+        )
+        #expect(!md.contains("Credentials:"))
+    }
+
+    @Test("Renders receivers when present")
+    func rendersReceivers() {
+        let md = AlertMarkdown.build(
+            for: makeAlert(
+                labels: ["alertname": "X", "severity": "warning"],
+                receivers: ["team-a", "team-b"]
+            ),
+            alertmanager: makeAlertmanager()
+        )
+        #expect(md.contains("**Receivers:** team-a, team-b"))
+    }
+
+    @Test("Omits receivers section when empty")
+    func omitsEmptyReceivers() {
+        let md = AlertMarkdown.build(
+            for: makeAlert(labels: ["alertname": "X", "severity": "warning"]),
+            alertmanager: makeAlertmanager()
+        )
+        #expect(!md.contains("**Receivers:**"))
+    }
+
+    @Test("Renders generator URL as Source")
+    func rendersSource() {
+        let md = AlertMarkdown.build(
+            for: makeAlert(
+                labels: ["alertname": "X", "severity": "warning"],
+                generatorURL: "http://prometheus:9090/graph"
+            ),
+            alertmanager: makeAlertmanager()
+        )
+        #expect(md.contains("**Source:** http://prometheus:9090/graph"))
+    }
+
+    @Test("Emits Description section from description annotation")
+    func descriptionSection() {
+        let md = AlertMarkdown.build(
+            for: makeAlert(
+                labels: ["alertname": "X", "severity": "warning"],
+                annotations: ["description": "Memory pressure detected"]
+            ),
+            alertmanager: makeAlertmanager()
+        )
+        #expect(md.contains("## Description"))
+        #expect(md.contains("Memory pressure detected"))
+    }
+
+    @Test("Skips Description section when annotation is whitespace only")
+    func skipsWhitespaceDescription() {
+        let md = AlertMarkdown.build(
+            for: makeAlert(
+                labels: ["alertname": "X", "severity": "warning"],
+                annotations: ["description": "   \n  "]
+            ),
+            alertmanager: makeAlertmanager()
+        )
+        #expect(!md.contains("## Description"))
+    }
+
+    @Test("Labels are sorted by key")
+    func labelsSorted() {
+        let md = AlertMarkdown.build(
+            for: makeAlert(
+                labels: [
+                    "alertname": "X",
+                    "severity": "warning",
+                    "zone": "us-east-1",
+                    "app": "api",
+                ]
+            ),
+            alertmanager: makeAlertmanager()
+        )
+        guard
+            let alertnameIdx = md.range(of: "`alertname`")?.lowerBound,
+            let appIdx = md.range(of: "`app`")?.lowerBound,
+            let severityIdx = md.range(of: "`severity`")?.lowerBound,
+            let zoneIdx = md.range(of: "`zone`")?.lowerBound
+        else {
+            Issue.record("expected all label keys to appear")
+            return
+        }
+        #expect(alertnameIdx < appIdx)
+        #expect(appIdx < severityIdx)
+        #expect(severityIdx < zoneIdx)
+    }
+
+    @Test("description and summary are omitted from the Annotations list")
+    func descriptionAndSummaryNotDuplicatedInAnnotations() {
+        let md = AlertMarkdown.build(
+            for: makeAlert(
+                labels: ["alertname": "X", "severity": "warning"],
+                annotations: [
+                    "description": "the description",
+                    "summary": "the summary",
+                    "runbook_url": "https://r.example.com",
+                ]
+            ),
+            alertmanager: makeAlertmanager()
+        )
+        #expect(md.contains("## Annotations"))
+        #expect(md.contains("`runbook_url`"))
+        // The Annotations section must not contain `description` or
+        // `summary` bullets — those are surfaced as a heading above.
+        if let range = md.range(of: "## Annotations") {
+            let suffix = md[range.lowerBound...]
+            #expect(!suffix.contains("`description`"))
+            #expect(!suffix.contains("`summary`"))
+        }
+    }
+
+    @Test("Summary and Description are emitted as separate sections, Summary first")
+    func summaryAndDescriptionSections() {
+        let md = AlertMarkdown.build(
+            for: makeAlert(
+                labels: ["alertname": "X", "severity": "warning"],
+                annotations: [
+                    "summary": "High memory pressure",
+                    "description": "Memory above 90% for 5m",
+                ]
+            ),
+            alertmanager: makeAlertmanager()
+        )
+        #expect(md.contains("## Summary"))
+        #expect(md.contains("High memory pressure"))
+        #expect(md.contains("## Description"))
+        #expect(md.contains("Memory above 90% for 5m"))
+        guard
+            let summaryIdx = md.range(of: "## Summary")?.lowerBound,
+            let descriptionIdx = md.range(of: "## Description")?.lowerBound
+        else {
+            Issue.record("expected both section headings to be rendered")
+            return
+        }
+        #expect(summaryIdx < descriptionIdx)
+    }
+
+    @Test("Summary section is emitted alone when no description is present")
+    func summaryWithoutDescription() {
+        let md = AlertMarkdown.build(
+            for: makeAlert(
+                labels: ["alertname": "X", "severity": "warning"],
+                annotations: ["summary": "Disk is full"]
+            ),
+            alertmanager: makeAlertmanager()
+        )
+        #expect(md.contains("## Summary"))
+        #expect(md.contains("Disk is full"))
+        #expect(!md.contains("## Description"))
+    }
+
+    @Test("Description section is emitted alone when no summary is present")
+    func descriptionWithoutSummary() {
+        let md = AlertMarkdown.build(
+            for: makeAlert(
+                labels: ["alertname": "X", "severity": "warning"],
+                annotations: ["description": "Detail text"]
+            ),
+            alertmanager: makeAlertmanager()
+        )
+        #expect(md.contains("## Description"))
+        #expect(md.contains("Detail text"))
+        #expect(!md.contains("## Summary"))
+    }
+
+    @Test("Whitespace-only summary is omitted")
+    func whitespaceSummaryOmitted() {
+        let md = AlertMarkdown.build(
+            for: makeAlert(
+                labels: ["alertname": "X", "severity": "warning"],
+                annotations: [
+                    "summary": "   ",
+                    "description": "Detail text",
+                ]
+            ),
+            alertmanager: makeAlertmanager()
+        )
+        #expect(!md.contains("## Summary"))
+        #expect(md.contains("## Description"))
+        #expect(md.contains("Detail text"))
+    }
+}


### PR DESCRIPTION
Adds a "copy as markdown" icon that appears next to an alert's title row
on hover. Clicking it writes a markdown snippet to the pasteboard so the
alert can be pasted directly into chat, issue trackers, or runbooks.

The snippet includes the backend's base URL and the resolved auth
credentials so the recipient can reproduce the underlying API call. For
Grafana backends the URL bullet is labeled "Grafana URL" (vs.
"Alertmanager URL") and the configured datasource is added, since a
Grafana base URL alone is not enough to identify which Alertmanager the
alert came from.

Summary and description annotations are surfaced as their own
"## Summary" / "## Description" sections — first thing a reader sees
after the metadata — and excluded from the generic Annotations list to
avoid duplication.

The outer toggle Button on the row header is replaced with an
onTapGesture so the nested copy Button is the sole hit target inside
its bounds — nested SwiftUI Buttons fight for clicks otherwise.