### PR TITLE
fix(aggregator): dedupe alerts in sidebar order across alertmanagers

### DIFF
--- a/Alertmanager/Services/AlertAggregator.swift
+++ b/Alertmanager/Services/AlertAggregator.swift
@@ -9,28 +9,42 @@ import Foundation
 /// per-alertmanager cache dictionary.
 ///
 /// The same "collect from multiple backends, deduplicate by fingerprint,
-/// apply filter" pattern is needed in at least three places
-/// (`SidebarFilterRowView`, `NotificationService`, `MenuBarContentView`).
-/// Centralising it here keeps behaviour consistent and makes it directly
-/// testable without touching any UI or system code.
+/// apply filter" pattern is needed in `SidebarFilterRowView` and
+/// `NotificationService`. Centralising it here keeps behaviour consistent
+/// and makes it directly testable without touching any UI or system code.
 enum AlertAggregator {
 
     /// Returns the set of alerts that match `filter`, gathered from the
     /// alertmanagers referenced by the filter.
+    ///
+    /// Alertmanagers are visited in the order given by
+    /// `orderedAlertmanagerIDs` (typically the sidebar order, sorted by
+    /// `Alertmanager.sortOrder`), so when the same alert fingerprint is
+    /// produced by multiple alertmanagers the first one in sidebar order
+    /// wins and later duplicates are dropped. `filter.selectedAlertmanagerIDs`
+    /// is treated as an unordered set membership filter rather than the
+    /// iteration order.
     ///
     /// - Parameters:
     ///   - filter: The filter whose `selectedAlertmanagerIDs` and predicates
     ///     are used.
     ///   - cache: A dictionary mapping alertmanager IDs to their cached alert
     ///     list (e.g. `AlertsManager.shared.alertsByAlertmanager`).
+    ///   - orderedAlertmanagerIDs: All known alertmanager IDs in their
+    ///     sidebar order. Determines dedup precedence when the same
+    ///     fingerprint appears in multiple alertmanagers.
     /// - Returns: Alerts matching every predicate in `filter`, deduplicated by
-    ///   `fingerprint`, preserving the order they were encountered per
-    ///   alertmanager.
-    static func alerts(for filter: Filter, from cache: [UUID: [GettableAlert]]) -> [GettableAlert] {
+    ///   `fingerprint`.
+    static func alerts(
+        for filter: Filter,
+        from cache: [UUID: [GettableAlert]],
+        orderedAlertmanagerIDs: [UUID]
+    ) -> [GettableAlert] {
+        let selected = Set(filter.selectedAlertmanagerIDs)
         var allAlerts: [GettableAlert] = []
         var seenFingerprints: Set<String> = []
 
-        for alertmanagerID in filter.selectedAlertmanagerIDs {
+        for alertmanagerID in orderedAlertmanagerIDs where selected.contains(alertmanagerID) {
             let cached = cache[alertmanagerID] ?? []
             for alert in cached {
                 if !seenFingerprints.contains(alert.fingerprint) {

--- a/Alertmanager/Services/NotificationService.swift
+++ b/Alertmanager/Services/NotificationService.swift
@@ -121,12 +121,16 @@ class NotificationService: NSObject {
 
         do {
             let filters = try modelContext.fetch(FetchDescriptor<Filter>())
-            let alertmanagers = try modelContext.fetch(FetchDescriptor<Alertmanager>())
+            let alertmanagers = try modelContext.fetch(
+                FetchDescriptor<Alertmanager>(sortBy: [SortDescriptor(\.sortOrder)])
+            )
+            let orderedIDs = alertmanagers.map(\.id)
 
             for filter in filters {
                 let allAlerts = AlertAggregator.alerts(
                     for: filter,
-                    from: AlertsManager.shared.alertsByAlertmanager
+                    from: AlertsManager.shared.alertsByAlertmanager,
+                    orderedAlertmanagerIDs: orderedIDs
                 ).sorted { $0.startsAt > $1.startsAt }
                 checkForNewAlerts(filter: filter, alerts: allAlerts, alertmanagers: alertmanagers)
             }
@@ -160,17 +164,37 @@ class NotificationService: NSObject {
     /// source(0), silence(1), runbook(2), dashboard(3), panel(4).
     private func registerNotificationCategories() {
         let allActions: [(bit: Int, action: UNNotificationAction)] = [
-            (0, UNNotificationAction(identifier: "OPEN_SOURCE",    title: "Source",    options: .foreground)),
-            (1, UNNotificationAction(identifier: "OPEN_SILENCE",   title: "Silence",   options: .foreground)),
-            (2, UNNotificationAction(identifier: "OPEN_RUNBOOK",   title: "Runbook",   options: .foreground)),
-            (3, UNNotificationAction(identifier: "OPEN_DASHBOARD", title: "Dashboard", options: .foreground)),
-            (4, UNNotificationAction(identifier: "OPEN_PANEL",     title: "Panel",     options: .foreground)),
+            (
+                0,
+                UNNotificationAction(
+                    identifier: "OPEN_SOURCE", title: "Source", options: .foreground)
+            ),
+            (
+                1,
+                UNNotificationAction(
+                    identifier: "OPEN_SILENCE", title: "Silence", options: .foreground)
+            ),
+            (
+                2,
+                UNNotificationAction(
+                    identifier: "OPEN_RUNBOOK", title: "Runbook", options: .foreground)
+            ),
+            (
+                3,
+                UNNotificationAction(
+                    identifier: "OPEN_DASHBOARD", title: "Dashboard", options: .foreground)
+            ),
+            (
+                4,
+                UNNotificationAction(identifier: "OPEN_PANEL", title: "Panel", options: .foreground)
+            ),
         ]
 
         var categories: Set<UNNotificationCategory> = []
         // Start at 1 — bitmask 0 means no actions, no category needed.
         for mask in 1..<32 {
-            let actions = allActions
+            let actions =
+                allActions
                 .filter { mask & (1 << $0.bit) != 0 }
                 .map { $0.action }
             let category = UNNotificationCategory(
@@ -196,11 +220,11 @@ class NotificationService: NSObject {
     /// - bit 4 → panel
     func categoryIdentifier(for userInfo: [String: String]) -> String {
         var mask = 0
-        if userInfo[NotificationUserInfoKey.sourceURL]    != nil { mask |= 1 << 0 }
-        if userInfo[NotificationUserInfoKey.silenceURL]   != nil { mask |= 1 << 1 }
-        if userInfo[NotificationUserInfoKey.runbookURL]   != nil { mask |= 1 << 2 }
+        if userInfo[NotificationUserInfoKey.sourceURL] != nil { mask |= 1 << 0 }
+        if userInfo[NotificationUserInfoKey.silenceURL] != nil { mask |= 1 << 1 }
+        if userInfo[NotificationUserInfoKey.runbookURL] != nil { mask |= 1 << 2 }
         if userInfo[NotificationUserInfoKey.dashboardURL] != nil { mask |= 1 << 3 }
-        if userInfo[NotificationUserInfoKey.panelURL]     != nil { mask |= 1 << 4 }
+        if userInfo[NotificationUserInfoKey.panelURL] != nil { mask |= 1 << 4 }
         return "ALERT_\(mask)"
     }
 
@@ -260,7 +284,8 @@ class NotificationService: NSObject {
             if !newFingerprints.isEmpty {
                 let newAlerts = alerts.filter { newFingerprints.contains($0.fingerprint) }
                 Task {
-                    await sendNotifications(for: newAlerts, filter: filter, alertmanagers: alertmanagers)
+                    await sendNotifications(
+                        for: newAlerts, filter: filter, alertmanagers: alertmanagers)
                 }
             }
 
@@ -328,7 +353,8 @@ class NotificationService: NSObject {
             // first (unless the UID is already the built-in "grafana" value).
             if let alertmanager {
                 let configuredUID =
-                    alertmanager.grafanaAlertmanager.isEmpty ? nil : alertmanager.grafanaAlertmanager
+                    alertmanager.grafanaAlertmanager.isEmpty
+                    ? nil : alertmanager.grafanaAlertmanager
                 let resolvedName: String?
                 if alertmanager.isGrafana, let uid = configuredUID, uid != "grafana" {
                     resolvedName = await service.fetchDatasourceName(for: uid, in: alertmanager)
@@ -514,7 +540,8 @@ extension NotificationService: UNUserNotificationCenterDelegate {
     nonisolated func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,
-        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) ->
+        withCompletionHandler completionHandler:
+            @escaping (UNNotificationPresentationOptions) ->
             Void
     ) {
         completionHandler([.banner, .sound])

--- a/Alertmanager/Views/SidebarFilterRowView.swift
+++ b/Alertmanager/Views/SidebarFilterRowView.swift
@@ -3,6 +3,7 @@
 //  Alertmanager
 //
 
+import SwiftData
 import SwiftUI
 
 /// Sidebar row representing a single `Filter`.
@@ -14,6 +15,11 @@ import SwiftUI
 struct SidebarFilterRowView: View {
     /// The filter this row represents.
     let filter: Filter
+
+    /// All alertmanagers in sidebar order. Used to give `AlertAggregator`
+    /// a stable visitation order so dedup precedence matches what the user
+    /// sees in the sidebar.
+    @Query(sort: \Alertmanager.sortOrder) private var alertmanagers: [Alertmanager]
 
     /// Cached count of matching alerts shown in the badge.
     @State private var alertCount: Int = 0
@@ -66,7 +72,8 @@ struct SidebarFilterRowView: View {
     private func updateAlertCount() {
         let filtered = AlertAggregator.alerts(
             for: filter,
-            from: AlertsManager.shared.alertsByAlertmanager
+            from: AlertsManager.shared.alertsByAlertmanager,
+            orderedAlertmanagerIDs: alertmanagers.map(\.id)
         )
         alertCount = filtered.count
     }

--- a/AlertmanagerTests/AlertAggregatorTests.swift
+++ b/AlertmanagerTests/AlertAggregatorTests.swift
@@ -47,7 +47,11 @@ struct AlertAggregatorTests {
             id2: [makeAlert(fingerprint: "b1")],
         ]
 
-        let result = AlertAggregator.alerts(for: filter, from: cache)
+        let result = AlertAggregator.alerts(
+            for: filter,
+            from: cache,
+            orderedAlertmanagerIDs: [id1, id2]
+        )
         let fps = Set(result.map(\.fingerprint))
         #expect(fps == ["a1", "a2"])
         #expect(!fps.contains("b1"))
@@ -68,11 +72,65 @@ struct AlertAggregatorTests {
             id2: [shared, makeAlert(fingerprint: "unique")],
         ]
 
-        let result = AlertAggregator.alerts(for: filter, from: cache)
+        let result = AlertAggregator.alerts(
+            for: filter,
+            from: cache,
+            orderedAlertmanagerIDs: [id1, id2]
+        )
         let fps = result.map(\.fingerprint)
         let sharedCount = fps.filter { $0 == "shared" }.count
         #expect(sharedCount == 1)
         #expect(fps.contains("unique"))
+    }
+
+    @Test("Dedup precedence follows the sidebar order, not the filter's ID order")
+    func dedupFollowsSidebarOrder() {
+        let id1 = UUID()
+        let id2 = UUID()
+        // Filter selection lists id2 first; sidebar order has id1 first.
+        // The id1 copy of the shared alert should win.
+        let filter = Filter(
+            name: "f",
+            selectedAlertmanagerIDs: [id2, id1],
+            states: []
+        )
+        let fromAM1 = makeAlert(fingerprint: "shared", labels: ["source": "am1"])
+        let fromAM2 = makeAlert(fingerprint: "shared", labels: ["source": "am2"])
+        let cache: [UUID: [GettableAlert]] = [
+            id1: [fromAM1],
+            id2: [fromAM2],
+        ]
+
+        let result = AlertAggregator.alerts(
+            for: filter,
+            from: cache,
+            orderedAlertmanagerIDs: [id1, id2]
+        )
+        #expect(result.count == 1)
+        #expect(result.first?.labels["source"] == "am1")
+    }
+
+    @Test("Ignores ordered IDs that are not in the filter's selection")
+    func ignoresUnselectedOrderedIDs() {
+        let selected = UUID()
+        let unselected = UUID()
+        let filter = Filter(
+            name: "f",
+            selectedAlertmanagerIDs: [selected],
+            states: []
+        )
+        let cache: [UUID: [GettableAlert]] = [
+            selected: [makeAlert(fingerprint: "in")],
+            unselected: [makeAlert(fingerprint: "out")],
+        ]
+
+        let result = AlertAggregator.alerts(
+            for: filter,
+            from: cache,
+            orderedAlertmanagerIDs: [unselected, selected]
+        )
+        let fps = result.map(\.fingerprint)
+        #expect(fps == ["in"])
     }
 
     @Test("Applies filter predicates (state predicate)")
@@ -90,7 +148,11 @@ struct AlertAggregatorTests {
             ]
         ]
 
-        let result = AlertAggregator.alerts(for: filter, from: cache)
+        let result = AlertAggregator.alerts(
+            for: filter,
+            from: cache,
+            orderedAlertmanagerIDs: [id]
+        )
         #expect(result.count == 1)
         #expect(result[0].fingerprint == "active")
     }
@@ -102,7 +164,11 @@ struct AlertAggregatorTests {
             selectedAlertmanagerIDs: [UUID()],
             states: []
         )
-        let result = AlertAggregator.alerts(for: filter, from: [:])
+        let result = AlertAggregator.alerts(
+            for: filter,
+            from: [:],
+            orderedAlertmanagerIDs: []
+        )
         #expect(result.isEmpty)
     }
 
@@ -110,7 +176,11 @@ struct AlertAggregatorTests {
     func emptyCache() {
         let id = UUID()
         let filter = Filter(name: "f", selectedAlertmanagerIDs: [id], states: [])
-        let result = AlertAggregator.alerts(for: filter, from: [id: []])
+        let result = AlertAggregator.alerts(
+            for: filter,
+            from: [id: []],
+            orderedAlertmanagerIDs: [id]
+        )
         #expect(result.isEmpty)
     }
 }


### PR DESCRIPTION
`Filter.selectedAlertmanagerIDs` is persisted from a `Set<UUID>`, so its
element order was hash-driven and unstable across saves. When the same
alert fingerprint was produced by multiple alertmanagers, the copy that
"won" deduplication in `AlertAggregator` was effectively random — and
unrelated to the alertmanager order the user sees in the sidebar.

Take a sidebar-sorted `orderedAlertmanagerIDs` parameter and use that
for iteration, treating `selectedAlertmanagerIDs` purely as a set
membership filter. The first alertmanager in sidebar order now wins
for a given fingerprint deterministically, and reordering alertmanagers
in the sidebar immediately changes which copy is kept.