### PR TITLE
test(ui): isolate stores and add fake-server + import/export coverage

### DIFF
--- a/Alertmanager.xcodeproj/project.pbxproj
+++ b/Alertmanager.xcodeproj/project.pbxproj
@@ -528,6 +528,7 @@
 		55AD68462FB2FB3600CBB850 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = AlertmanagerUITests/AlertmanagerUITests.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 75AP6HWLUD;
@@ -548,6 +549,7 @@
 		55AD68472FB2FB3600CBB850 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = AlertmanagerUITests/AlertmanagerUITests.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 75AP6HWLUD;

--- a/Alertmanager/AlertmanagerApp.swift
+++ b/Alertmanager/AlertmanagerApp.swift
@@ -51,9 +51,7 @@ struct AlertmanagerApp: App {
         let modelConfiguration = ModelConfiguration(schema: schema, url: url)
 
         do {
-            let container = try ModelContainer(for: schema, configurations: [modelConfiguration])
-            seedFromLaunchArgumentsIfNeeded(container: container)
-            return container
+            return try ModelContainer(for: schema, configurations: [modelConfiguration])
         } catch {
             fatalError("Failed to create ModelContainer: \(error)")
         }
@@ -67,6 +65,13 @@ struct AlertmanagerApp: App {
             ContentView()
                 .onAppear {
                     NotificationService.shared.configure(with: sharedModelContainer)
+                    // Apply the UI-test seed AFTER the view has appeared,
+                    // so `ContentView`'s `@Query` is already observing the
+                    // container and picks up the inserted row. Seeding in
+                    // the container-init closure works on some macOS
+                    // versions but races `@Query` observer registration on
+                    // others (CI runners observed the row never appearing).
+                    seedFromLaunchArgumentsIfNeeded(container: sharedModelContainer)
                     // One-shot version probe against the GitHub releases
                     // API. Subsequent `.onAppear` calls within the same
                     // session are no-ops — the banner is a launch hint.
@@ -132,10 +137,10 @@ struct AlertmanagerApp: App {
 /// Inserts a single `Alertmanager` row when the app is launched with
 /// `-uiTestSeedAlertmanagerURL <url>`. No-op outside of that flag.
 ///
-/// Lets UI tests skip the create-alertmanager form flow and start from a
-/// known-good store pointing at a loopback `FakeAlertmanagerServer`. Uses
-/// `container.mainContext` so the views' `@Query` reads the seeded row on
-/// first render, instead of racing a cross-context save notification.
+/// Idempotent: skips the insert when the store already has alertmanagers,
+/// so a window re-appear or a second invocation doesn't create duplicates.
+/// Called from `ContentView`'s `.onAppear` so `@Query` is registered as
+/// an observer before the row is inserted.
 @MainActor
 private func seedFromLaunchArgumentsIfNeeded(container: ModelContainer) {
     let args = ProcessInfo.processInfo.arguments
@@ -143,8 +148,12 @@ private func seedFromLaunchArgumentsIfNeeded(container: ModelContainer) {
         flagIndex + 1 < args.count
     else { return }
 
-    let url = args[flagIndex + 1]
     let context = container.mainContext
+
+    let existing = (try? context.fetch(FetchDescriptor<Alertmanager>())) ?? []
+    if !existing.isEmpty { return }
+
+    let url = args[flagIndex + 1]
     context.insert(
         Alertmanager(
             name: "Test AM",

--- a/Alertmanager/AlertmanagerApp.swift
+++ b/Alertmanager/AlertmanagerApp.swift
@@ -24,18 +24,36 @@ struct AlertmanagerApp: App {
     /// `~/Library/Application Support/de.ricoberger.Alertmanager/default.sqlite`.
     /// Container creation is fatal — the app cannot function without
     /// persistence.
+    ///
+    /// UI tests launch the app with `-uiTestResetStore`, which redirects the
+    /// SQLite file to a unique path under the temporary directory. This keeps
+    /// each test launch isolated from prior runs (and from the user's real
+    /// data) while still exercising the on-disk persistence path.
+    ///
+    /// UI tests can additionally pass `-uiTestSeedAlertmanagerURL <url>` to
+    /// pre-populate the store with a single `Alertmanager` row pointed at the
+    /// given URL (typically a loopback `FakeAlertmanagerServer`). This skips
+    /// the form-typing flow when a test only cares about display behavior.
     var sharedModelContainer: ModelContainer = {
         let schema = Schema([
             Alertmanager.self,
             Filter.self,
         ])
 
-        let url = URL.applicationSupportDirectory.appending(
-            path: "de.ricoberger.Alertmanager/default.sqlite")
+        let url: URL
+        if ProcessInfo.processInfo.arguments.contains("-uiTestResetStore") {
+            url = FileManager.default.temporaryDirectory.appending(
+                path: "Alertmanager-UITests-\(UUID().uuidString).sqlite")
+        } else {
+            url = URL.applicationSupportDirectory.appending(
+                path: "de.ricoberger.Alertmanager/default.sqlite")
+        }
         let modelConfiguration = ModelConfiguration(schema: schema, url: url)
 
         do {
-            return try ModelContainer(for: schema, configurations: [modelConfiguration])
+            let container = try ModelContainer(for: schema, configurations: [modelConfiguration])
+            seedFromLaunchArgumentsIfNeeded(container: container)
+            return container
         } catch {
             fatalError("Failed to create ModelContainer: \(error)")
         }
@@ -108,5 +126,37 @@ struct AlertmanagerApp: App {
             SettingsView()
                 .modelContainer(sharedModelContainer)
         }
+    }
+}
+
+/// Inserts a single `Alertmanager` row when the app is launched with
+/// `-uiTestSeedAlertmanagerURL <url>`. No-op outside of that flag.
+///
+/// Lets UI tests skip the create-alertmanager form flow and start from a
+/// known-good store pointing at a loopback `FakeAlertmanagerServer`. Uses
+/// `container.mainContext` so the views' `@Query` reads the seeded row on
+/// first render, instead of racing a cross-context save notification.
+@MainActor
+private func seedFromLaunchArgumentsIfNeeded(container: ModelContainer) {
+    let args = ProcessInfo.processInfo.arguments
+    guard let flagIndex = args.firstIndex(of: "-uiTestSeedAlertmanagerURL"),
+        flagIndex + 1 < args.count
+    else { return }
+
+    let url = args[flagIndex + 1]
+    let context = container.mainContext
+    context.insert(
+        Alertmanager(
+            name: "Test AM",
+            url: url,
+            isGrafana: false,
+            grafanaAlertmanager: "",
+            authType: .none
+        )
+    )
+    do {
+        try context.save()
+    } catch {
+        fatalError("UI test seed failed: \(error)")
     }
 }

--- a/Alertmanager/AlertmanagerApp.swift
+++ b/Alertmanager/AlertmanagerApp.swift
@@ -65,13 +65,6 @@ struct AlertmanagerApp: App {
             ContentView()
                 .onAppear {
                     NotificationService.shared.configure(with: sharedModelContainer)
-                    // Apply the UI-test seed AFTER the view has appeared,
-                    // so `ContentView`'s `@Query` is already observing the
-                    // container and picks up the inserted row. Seeding in
-                    // the container-init closure works on some macOS
-                    // versions but races `@Query` observer registration on
-                    // others (CI runners observed the row never appearing).
-                    seedFromLaunchArgumentsIfNeeded(container: sharedModelContainer)
                     // One-shot version probe against the GitHub releases
                     // API. Subsequent `.onAppear` calls within the same
                     // session are no-ops — the banner is a launch hint.
@@ -134,38 +127,3 @@ struct AlertmanagerApp: App {
     }
 }
 
-/// Inserts a single `Alertmanager` row when the app is launched with
-/// `-uiTestSeedAlertmanagerURL <url>`. No-op outside of that flag.
-///
-/// Idempotent: skips the insert when the store already has alertmanagers,
-/// so a window re-appear or a second invocation doesn't create duplicates.
-/// Called from `ContentView`'s `.onAppear` so `@Query` is registered as
-/// an observer before the row is inserted.
-@MainActor
-private func seedFromLaunchArgumentsIfNeeded(container: ModelContainer) {
-    let args = ProcessInfo.processInfo.arguments
-    guard let flagIndex = args.firstIndex(of: "-uiTestSeedAlertmanagerURL"),
-        flagIndex + 1 < args.count
-    else { return }
-
-    let context = container.mainContext
-
-    let existing = (try? context.fetch(FetchDescriptor<Alertmanager>())) ?? []
-    if !existing.isEmpty { return }
-
-    let url = args[flagIndex + 1]
-    context.insert(
-        Alertmanager(
-            name: "Test AM",
-            url: url,
-            isGrafana: false,
-            grafanaAlertmanager: "",
-            authType: .none
-        )
-    )
-    do {
-        try context.save()
-    } catch {
-        fatalError("UI test seed failed: \(error)")
-    }
-}

--- a/Alertmanager/ContentView.swift
+++ b/Alertmanager/ContentView.swift
@@ -324,11 +324,20 @@ struct ContentView: View {
     /// Serializes the current configuration to JSON and prompts the user
     /// for a save location via `NSSavePanel`. Silent on cancellation;
     /// failures are logged.
+    ///
+    /// UI tests can short-circuit the save panel by passing
+    /// `-uiTestExportPath <path>` at launch; the export is then written
+    /// directly to that file path.
     private func exportConfiguration() {
         guard
             let data = ImportExportManager.exportData(
                 alertmanagers: alertmanagers, filters: filters)
         else {
+            return
+        }
+
+        if let path = uiTestLaunchArgumentValue(for: "-uiTestExportPath") {
+            try? data.write(to: URL(fileURLWithPath: path))
             return
         }
 
@@ -351,42 +360,70 @@ struct ContentView: View {
     /// contents into the current `modelContext`, and starts polling for any
     /// newly added alertmanagers. Reports the outcome through the
     /// "Import Complete" alert.
+    ///
+    /// UI tests can short-circuit the open panel by passing
+    /// `-uiTestImportPath <path>` at launch; the import is then read
+    /// directly from that file path.
     private func importConfiguration() {
+        if let path = uiTestLaunchArgumentValue(for: "-uiTestImportPath") {
+            importConfigurationData(from: URL(fileURLWithPath: path))
+            return
+        }
+
         let panel = NSOpenPanel()
         panel.allowedContentTypes = [UTType.json]
         panel.allowsMultipleSelection = false
 
         panel.begin { response in
             if response == .OK, let url = panel.url {
-                do {
-                    let data = try Data(contentsOf: url)
-                    let result = try ImportExportManager.importData(
-                        from: data,
-                        modelContext: modelContext,
-                        existingAlertmanagers: alertmanagers
-                    )
-
-                    var message =
-                        "Successfully imported \(result.alertmanagers) alertmanager(s) and \(result.filters) filter(s)."
-                    if result.settingsRestored {
-                        message += " Settings have been restored."
-                    }
-                    importMessage = message
-                    showingImportAlert = true
-
-                    // Begin polling for any alertmanagers added by the import.
-                    // `startMonitoring` is idempotent for entries that were
-                    // already being polled.
-                    for alertmanager in alertmanagers {
-                        AlertsManager.shared.startMonitoring(alertmanager: alertmanager)
-                    }
-                } catch {
-                    importMessage =
-                        "Failed to import configuration: \(error.localizedDescription)"
-                    showingImportAlert = true
-                }
+                importConfigurationData(from: url)
             }
         }
+    }
+
+    /// Reads a JSON export from `url`, applies it via
+    /// `ImportExportManager.importData`, and surfaces the outcome through
+    /// the post-import alert. Extracted so both the open-panel callback
+    /// and the UI test launch-arg path share the same code.
+    private func importConfigurationData(from url: URL) {
+        do {
+            let data = try Data(contentsOf: url)
+            let result = try ImportExportManager.importData(
+                from: data,
+                modelContext: modelContext,
+                existingAlertmanagers: alertmanagers
+            )
+
+            var message =
+                "Successfully imported \(result.alertmanagers) alertmanager(s) and \(result.filters) filter(s)."
+            if result.settingsRestored {
+                message += " Settings have been restored."
+            }
+            importMessage = message
+            showingImportAlert = true
+
+            // Begin polling for any alertmanagers added by the import.
+            // `startMonitoring` is idempotent for entries that were
+            // already being polled.
+            for alertmanager in alertmanagers {
+                AlertsManager.shared.startMonitoring(alertmanager: alertmanager)
+            }
+        } catch {
+            importMessage =
+                "Failed to import configuration: \(error.localizedDescription)"
+            showingImportAlert = true
+        }
+    }
+
+    /// Looks up the value immediately following `flag` in
+    /// `ProcessInfo.processInfo.arguments`. Returns `nil` when the flag
+    /// is absent or has no successor.
+    private func uiTestLaunchArgumentValue(for flag: String) -> String? {
+        let args = ProcessInfo.processInfo.arguments
+        guard let index = args.firstIndex(of: flag), index + 1 < args.count else {
+            return nil
+        }
+        return args[index + 1]
     }
 
     /// Deletes all alertmanagers and filters from the SwiftData store,

--- a/Alertmanager/ContentView.swift
+++ b/Alertmanager/ContentView.swift
@@ -157,11 +157,12 @@ struct ContentView: View {
         .onAppear {
             // Apply the UI-test seed (no-op outside UI tests) using this
             // view's environment `modelContext` — the same context the
-            // `@Query` above observes. Inserting through `mainContext`
-            // directly raced observer registration on CI macOS 26 runners
-            // and the row never surfaced in the sidebar; routing through
-            // the environment context (the path the form-based create
-            // already uses successfully) avoids that race.
+            // `@Query` above observes. Driven by the
+            // `UI_TEST_SEED_ALERTMANAGER_URL` environment variable: macOS
+            // 26 parses `-key value` launch-arg pairs into `NSUserDefaults`
+            // and URL/path values in that table prevent the app's main
+            // window from appearing at all, so URL/path hooks travel via
+            // the environment instead.
             seedFromLaunchArgumentsIfNeeded()
             // Kick off polling for every persisted alertmanager. Repeated
             // calls are safe — `AlertsManager` replaces any existing timer
@@ -333,9 +334,9 @@ struct ContentView: View {
     /// for a save location via `NSSavePanel`. Silent on cancellation;
     /// failures are logged.
     ///
-    /// UI tests can short-circuit the save panel by passing
-    /// `-uiTestExportPath <path>` at launch; the export is then written
-    /// directly to that file path.
+    /// UI tests can short-circuit the save panel by setting
+    /// `UI_TEST_EXPORT_PATH` in the launch environment; the export is
+    /// then written directly to that file path.
     private func exportConfiguration() {
         guard
             let data = ImportExportManager.exportData(
@@ -344,7 +345,7 @@ struct ContentView: View {
             return
         }
 
-        if let path = uiTestLaunchArgumentValue(for: "-uiTestExportPath") {
+        if let path = uiTestEnvironmentValue(for: "UI_TEST_EXPORT_PATH") {
             try? data.write(to: URL(fileURLWithPath: path))
             return
         }
@@ -369,11 +370,11 @@ struct ContentView: View {
     /// newly added alertmanagers. Reports the outcome through the
     /// "Import Complete" alert.
     ///
-    /// UI tests can short-circuit the open panel by passing
-    /// `-uiTestImportPath <path>` at launch; the import is then read
-    /// directly from that file path.
+    /// UI tests can short-circuit the open panel by setting
+    /// `UI_TEST_IMPORT_PATH` in the launch environment; the import is
+    /// then read directly from that file path.
     private func importConfiguration() {
-        if let path = uiTestLaunchArgumentValue(for: "-uiTestImportPath") {
+        if let path = uiTestEnvironmentValue(for: "UI_TEST_IMPORT_PATH") {
             importConfigurationData(from: URL(fileURLWithPath: path))
             return
         }
@@ -423,41 +424,41 @@ struct ContentView: View {
         }
     }
 
-    /// Looks up the value immediately following `flag` in
-    /// `ProcessInfo.processInfo.arguments`. Returns `nil` when the flag
-    /// is absent or has no successor.
-    private func uiTestLaunchArgumentValue(for flag: String) -> String? {
-        let args = ProcessInfo.processInfo.arguments
-        guard let index = args.firstIndex(of: flag), index + 1 < args.count else {
-            return nil
-        }
-        return args[index + 1]
+    /// Reads `name` from `ProcessInfo.processInfo.environment`. UI tests
+    /// pass URL- and file-path-valued hooks via the environment rather
+    /// than launch arguments because macOS 26 parses `-key value` arg
+    /// pairs into `NSUserDefaults`, and URL/path values in that table
+    /// suppress the app's main window from appearing at all.
+    private func uiTestEnvironmentValue(for name: String) -> String? {
+        let value = ProcessInfo.processInfo.environment[name]
+        return (value?.isEmpty == false) ? value : nil
     }
 
     /// Inserts a single `Alertmanager` row when the app is launched with
-    /// `-uiTestSeedAlertmanagerURL <url>`. No-op outside of that flag.
+    /// the `UI_TEST_SEED_ALERTMANAGER_URL` environment variable set.
+    /// No-op outside of that variable being present.
     ///
-    /// Idempotent via the `@Query`-backed `alertmanagers` array: the seed
-    /// only runs when the store is empty, so window re-appears or any
-    /// second invocation can't create duplicates. The insert is routed
-    /// through the environment `modelContext` (the same one `@Query`
-    /// observes) and relies on SwiftData's autosave — calling `save()`
-    /// explicitly raced observer registration on CI runners. The
-    /// alertmanager-name-form code path uses this same pattern.
+    /// Mirrors `AlertmanagerFormView.saveAlertmanager`'s create path:
+    /// explicit `fetch` via the env `modelContext` for idempotency,
+    /// explicit `sortOrder`, autosave only — the same shape the form-
+    /// driven CRUD tests exercise successfully.
     private func seedFromLaunchArgumentsIfNeeded() {
-        guard alertmanagers.isEmpty,
-            let url = uiTestLaunchArgumentValue(for: "-uiTestSeedAlertmanagerURL")
-        else { return }
+        guard let url = uiTestEnvironmentValue(for: "UI_TEST_SEED_ALERTMANAGER_URL") else {
+            return
+        }
 
-        modelContext.insert(
-            Alertmanager(
-                name: "Test AM",
-                url: url,
-                isGrafana: false,
-                grafanaAlertmanager: "",
-                authType: .none
-            )
+        let existing = (try? modelContext.fetch(FetchDescriptor<Alertmanager>())) ?? []
+        guard existing.isEmpty else { return }
+
+        let newAlertmanager = Alertmanager(
+            name: "Test AM",
+            url: url,
+            isGrafana: false,
+            grafanaAlertmanager: "",
+            authType: .none,
+            sortOrder: 0
         )
+        modelContext.insert(newAlertmanager)
     }
 
     /// Deletes all alertmanagers and filters from the SwiftData store,

--- a/Alertmanager/ContentView.swift
+++ b/Alertmanager/ContentView.swift
@@ -155,6 +155,14 @@ struct ContentView: View {
             }
         }
         .onAppear {
+            // Apply the UI-test seed (no-op outside UI tests) using this
+            // view's environment `modelContext` — the same context the
+            // `@Query` above observes. Inserting through `mainContext`
+            // directly raced observer registration on CI macOS 26 runners
+            // and the row never surfaced in the sidebar; routing through
+            // the environment context (the path the form-based create
+            // already uses successfully) avoids that race.
+            seedFromLaunchArgumentsIfNeeded()
             // Kick off polling for every persisted alertmanager. Repeated
             // calls are safe — `AlertsManager` replaces any existing timer
             // for the same alertmanager id.
@@ -424,6 +432,32 @@ struct ContentView: View {
             return nil
         }
         return args[index + 1]
+    }
+
+    /// Inserts a single `Alertmanager` row when the app is launched with
+    /// `-uiTestSeedAlertmanagerURL <url>`. No-op outside of that flag.
+    ///
+    /// Idempotent via the `@Query`-backed `alertmanagers` array: the seed
+    /// only runs when the store is empty, so window re-appears or any
+    /// second invocation can't create duplicates. The insert is routed
+    /// through the environment `modelContext` (the same one `@Query`
+    /// observes) and relies on SwiftData's autosave — calling `save()`
+    /// explicitly raced observer registration on CI runners. The
+    /// alertmanager-name-form code path uses this same pattern.
+    private func seedFromLaunchArgumentsIfNeeded() {
+        guard alertmanagers.isEmpty,
+            let url = uiTestLaunchArgumentValue(for: "-uiTestSeedAlertmanagerURL")
+        else { return }
+
+        modelContext.insert(
+            Alertmanager(
+                name: "Test AM",
+                url: url,
+                isGrafana: false,
+                grafanaAlertmanager: "",
+                authType: .none
+            )
+        )
     }
 
     /// Deletes all alertmanagers and filters from the SwiftData store,

--- a/Alertmanager/Views/AlertRowView.swift
+++ b/Alertmanager/Views/AlertRowView.swift
@@ -323,6 +323,7 @@ struct AlertRowView: View {
             RoundedRectangle(cornerRadius: 8)
                 .stroke(isExpandedState ? Color.blue.opacity(0.3) : Color.clear, lineWidth: 1)
         )
+        .accessibilityIdentifier("alert-row-\(alert.alertName)")
         .onAppear {
             isExpandedState = isExpanded
         }

--- a/Alertmanager/Views/SidebarAlertmanagerRowView.swift
+++ b/Alertmanager/Views/SidebarAlertmanagerRowView.swift
@@ -42,6 +42,10 @@ struct SidebarAlertmanagerRowView: View {
                 // Orange warning badge signalling the most recent fetch
                 // failed. The error message is surfaced via the help
                 // tooltip so users can diagnose the issue on hover.
+                //
+                // The explicit accessibilityLabel makes the failure state
+                // detectable by UI tests via the enclosing sidebar row's
+                // combined accessibility label.
                 Image(systemName: "exclamationmark.triangle.fill")
                     .font(.caption)
                     .fontWeight(.semibold)
@@ -51,6 +55,7 @@ struct SidebarAlertmanagerRowView: View {
                     .background(Color.orange)
                     .clipShape(Capsule())
                     .help(errorMessage)
+                    .accessibilityLabel("Fetch error")
             } else {
                 // Capsule badge with the current alert count. Red signals
                 // there are active alerts, green signals all-clear.

--- a/AlertmanagerUITests/AlertDisplayTests.swift
+++ b/AlertmanagerUITests/AlertDisplayTests.swift
@@ -1,0 +1,142 @@
+//
+//  AlertDisplayTests.swift
+//  AlertmanagerUITests
+//
+
+import XCTest
+
+/// UI tests that exercise the alert-fetching and display path end to end
+/// against a loopback `FakeAlertmanagerServer`, so the sidebar count
+/// badge, the empty / error states, and the `AlertRowView` itself are
+/// covered without depending on a real Alertmanager backend.
+final class AlertDisplayTests: XCTestCase {
+    var app: XCUIApplication!
+    var server: FakeAlertmanagerServer!
+
+    override func tearDownWithError() throws {
+        server?.stop()
+        app?.terminate()
+    }
+
+    // MARK: - Helpers
+
+    /// Boots the fake server with `response`, launches the app pointed at
+    /// it with a freshly-seeded `Test AM` row, and returns the launched
+    /// application.
+    private func launchWithFakeServer(response: FakeAlertmanagerServer.Response) throws
+        -> XCUIApplication
+    {
+        server = try FakeAlertmanagerServer(response: response)
+        try server.start()
+
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-uiTestResetStore",
+            "-uiTestSeedAlertmanagerURL", server.baseURL,
+        ]
+        app.launch()
+        self.app = app
+        return app
+    }
+
+    /// Returns the sidebar row button for the seeded `Test AM` alertmanager,
+    /// waiting up to 10s for it to appear.
+    private func seededSidebarRow() -> XCUIElement {
+        // SwiftUI merges child accessibility identifiers into the row's
+        // Button, so the button's identifier is a prefix-match rather than
+        // an exact match.
+        let row = app.descendants(matching: .button).matching(
+            NSPredicate(format: "identifier BEGINSWITH 'sidebar-alertmanager-name-Test AM'")
+        ).firstMatch
+        XCTAssertTrue(row.waitForExistence(timeout: 10))
+        return row
+    }
+
+    /// Waits until the sidebar row's accessibility label satisfies
+    /// `predicate`, polling once a second.
+    private func waitForRowLabel(
+        _ row: XCUIElement, matching predicate: (String) -> Bool, timeout: TimeInterval = 10
+    ) -> String? {
+        let deadline = Date().addingTimeInterval(timeout)
+        var lastLabel = row.label
+        while Date() < deadline {
+            lastLabel = row.label
+            if predicate(lastLabel) { return lastLabel }
+            Thread.sleep(forTimeInterval: 0.5)
+        }
+        return predicate(lastLabel) ? lastLabel : nil
+    }
+
+    // MARK: - Populated
+
+    @MainActor
+    func testWatchdogAlertRenders() throws {
+        _ = try launchWithFakeServer(
+            response: .alerts(json: FakeAlertmanagerPayloads.watchdog))
+        let row = seededSidebarRow()
+        row.click()
+
+        // SwiftUI propagates the `alert-row-Watchdog` accessibility identifier
+        // (set on the row's outer VStack) down to every static text inside
+        // the row. Match against any of those texts via the staticTexts
+        // query, which has reliable wait semantics.
+        let rowText = app.staticTexts.matching(identifier: "alert-row-Watchdog").firstMatch
+        XCTAssertTrue(
+            rowText.waitForExistence(timeout: 10),
+            "alert-row-Watchdog never appeared in detail view")
+
+        // The headline text includes the alertmanager-name prefix because
+        // `showAlertmanagerName` defaults to true.
+        XCTAssertTrue(app.staticTexts["[Test AM] Watchdog"].exists)
+
+        // The summary annotation is visible on the collapsed row.
+        let summaryPredicate = NSPredicate(
+            format: "identifier == 'alert-row-Watchdog' AND value CONTAINS 'alerting pipeline'")
+        XCTAssertTrue(app.staticTexts.matching(summaryPredicate).firstMatch.exists)
+    }
+
+    @MainActor
+    func testSidebarCountBadgeReflectsAlerts() throws {
+        _ = try launchWithFakeServer(
+            response: .alerts(json: FakeAlertmanagerPayloads.watchdog))
+
+        // Children's accessibility labels are merged into the row Button's
+        // label, so the count "1" appears as the trailing comma-separated
+        // segment once the first poll completes.
+        let row = seededSidebarRow()
+        let label = waitForRowLabel(row) { $0.hasSuffix(", 1") }
+        XCTAssertNotNil(label, "expected row label to end with ', 1', got \(row.label)")
+    }
+
+    // MARK: - Empty
+
+    @MainActor
+    func testEmptyResponseShowsZeroCount() throws {
+        _ = try launchWithFakeServer(
+            response: .alerts(json: FakeAlertmanagerPayloads.empty))
+
+        let row = seededSidebarRow()
+        let label = waitForRowLabel(row) { $0.hasSuffix(", 0") }
+        XCTAssertNotNil(label, "expected row label to end with ', 0', got \(row.label)")
+
+        row.click()
+        XCTAssertTrue(app.staticTexts["No Alerts"].waitForExistence(timeout: 5))
+    }
+
+    // MARK: - Error
+
+    @MainActor
+    func testServerErrorShowsErrorBadge() throws {
+        _ = try launchWithFakeServer(response: .status(500))
+
+        // `Fetch error` is the accessibility label installed on the orange
+        // warning badge in `SidebarAlertmanagerRowView`. It gets merged into
+        // the enclosing row Button's label once the failed poll lands.
+        let row = seededSidebarRow()
+        let label = waitForRowLabel(row) { $0.contains("Fetch error") }
+        XCTAssertNotNil(label, "expected row label to contain 'Fetch error', got \(row.label)")
+
+        row.click()
+        XCTAssertTrue(app.staticTexts["Failed to load alerts"].waitForExistence(timeout: 5))
+    }
+}

--- a/AlertmanagerUITests/AlertDisplayTests.swift
+++ b/AlertmanagerUITests/AlertDisplayTests.swift
@@ -30,10 +30,12 @@ final class AlertDisplayTests: XCTestCase {
         try server.start()
 
         let app = XCUIApplication()
-        app.launchArguments += [
-            "-uiTestResetStore",
-            "-uiTestSeedAlertmanagerURL", server.baseURL,
-        ]
+        app.launchArguments += ["-uiTestResetStore"]
+        // URL/path-shaped values travel via the environment instead of
+        // `launchArguments`. macOS 26 parses `-key value` argument pairs
+        // into `NSUserDefaults`, and URL/path-typed entries in that table
+        // prevent the app's main window from appearing at all.
+        app.launchEnvironment["UI_TEST_SEED_ALERTMANAGER_URL"] = server.baseURL
         app.launch()
         self.app = app
         return app

--- a/AlertmanagerUITests/AlertmanagerCRUDTests.swift
+++ b/AlertmanagerUITests/AlertmanagerCRUDTests.swift
@@ -13,6 +13,7 @@ final class AlertmanagerCRUDTests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
+        app.launchArguments += ["-uiTestResetStore"]
         app.launch()
     }
 
@@ -102,8 +103,7 @@ final class AlertmanagerCRUDTests: XCTestCase {
 
     @MainActor
     func testDeleteAlertmanagerRemovesFromSidebar() throws {
-        // Use a unique name to avoid collisions with prior test runs.
-        let name = "DeleteMe-\(Int(Date().timeIntervalSince1970))"
+        let name = "DeleteMe"
 
         openAddAlertmanagerSheet()
         let nameField = waitForFormSheet()

--- a/AlertmanagerUITests/AlertmanagerUITests.entitlements
+++ b/AlertmanagerUITests/AlertmanagerUITests.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+</dict>
+</plist>

--- a/AlertmanagerUITests/FakeAlertmanagerServer.swift
+++ b/AlertmanagerUITests/FakeAlertmanagerServer.swift
@@ -1,0 +1,139 @@
+//
+//  FakeAlertmanagerServer.swift
+//  AlertmanagerUITests
+//
+
+import Foundation
+import Network
+
+/// Minimal in-test HTTP server that serves canned `GET /api/v2/alerts`
+/// responses for the UI test suite.
+///
+/// Listens on `127.0.0.1` with an OS-assigned port. The resolved
+/// `http://127.0.0.1:<port>` URL is passed to the app under test via the
+/// `-uiTestSeedAlertmanagerURL` launch argument, so the seeded `Alertmanager`
+/// row in SwiftData points at this listener.
+///
+/// The server is intentionally minimal: it reads up to one buffer of bytes
+/// from each connection, ignores the request line, and writes the configured
+/// response. That's enough to exercise the app's fetch + render path for
+/// the populated, empty, and error-status sidebar states without dragging
+/// in a third-party HTTP library.
+final class FakeAlertmanagerServer {
+    /// Canned response served on the next `/api/v2/alerts` request.
+    enum Response {
+        /// HTTP 200 with the supplied JSON body as `application/json`.
+        case alerts(json: String)
+        /// HTTP `code` with an empty body — used to verify the app's
+        /// error-state sidebar badge.
+        case status(Int)
+    }
+
+    private let listener: NWListener
+    private let queue = DispatchQueue(label: "FakeAlertmanagerServer")
+    private var response: Response
+
+    /// Port the listener bound to. Valid only after `start()` returns.
+    private(set) var port: UInt16 = 0
+
+    /// Loopback base URL pointing at this listener. Pass to the app via
+    /// `-uiTestSeedAlertmanagerURL`.
+    var baseURL: String { "http://127.0.0.1:\(port)" }
+
+    init(response: Response) throws {
+        self.response = response
+        self.listener = try NWListener(using: .tcp)
+    }
+
+    /// Binds the listener and blocks until it reaches the `.ready` state, so
+    /// callers can read `port` immediately after `start()` returns. Throws
+    /// if the listener does not become ready within 5 seconds.
+    func start() throws {
+        let ready = DispatchSemaphore(value: 0)
+        var readyError: Error?
+
+        listener.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
+            switch state {
+            case .ready:
+                if let p = self.listener.port {
+                    self.port = p.rawValue
+                }
+                ready.signal()
+            case .failed(let error):
+                readyError = error
+                ready.signal()
+            default:
+                break
+            }
+        }
+        listener.newConnectionHandler = { [weak self] connection in
+            self?.handle(connection: connection)
+        }
+        listener.start(queue: queue)
+
+        if ready.wait(timeout: .now() + .seconds(5)) == .timedOut {
+            throw NSError(
+                domain: "FakeAlertmanagerServer", code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Listener did not become ready in time"])
+        }
+        if let readyError {
+            throw readyError
+        }
+    }
+
+    /// Cancels the listener. Safe to call multiple times.
+    func stop() {
+        listener.cancel()
+    }
+
+    /// Swaps the canned response served by subsequent connections.
+    func setResponse(_ response: Response) {
+        queue.async { self.response = response }
+    }
+
+    private func handle(connection: NWConnection) {
+        connection.start(queue: queue)
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 8192) {
+            [weak self] _, _, _, _ in
+            guard let self else {
+                connection.cancel()
+                return
+            }
+            let payload = self.buildResponseBytes(for: self.response)
+            connection.send(
+                content: payload,
+                completion: .contentProcessed { _ in connection.cancel() })
+        }
+    }
+
+    private func buildResponseBytes(for response: Response) -> Data {
+        switch response {
+        case .alerts(let json):
+            let body = Data(json.utf8)
+            var header = "HTTP/1.1 200 OK\r\n"
+            header += "Content-Type: application/json\r\n"
+            header += "Content-Length: \(body.count)\r\n"
+            header += "Connection: close\r\n\r\n"
+            return Data(header.utf8) + body
+        case .status(let code):
+            var header = "HTTP/1.1 \(code) Error\r\n"
+            header += "Content-Length: 0\r\n"
+            header += "Connection: close\r\n\r\n"
+            return Data(header.utf8)
+        }
+    }
+}
+
+/// Canned `/api/v2/alerts` payloads used by the UI tests.
+enum FakeAlertmanagerPayloads {
+    /// Single firing Watchdog alert — mirrors the canonical Alertmanager
+    /// dead-man-switch alert that's expected to always be active.
+    static let watchdog = """
+        [{"annotations":{"description":"This is an alert meant to ensure that the entire alerting pipeline is functional. This alert is always firing, therefore it should always be firing in Alertmanager and always fire against a receiver. There are integrations with various notification mechanisms that send a notification when this alert is not firing. For example the \\"DeadMansSnitch\\" integration in PagerDuty.","summary":"Ensure entire alerting pipeline is functional"},"endsAt":"2026-05-20T05:02:41.872Z","fingerprint":"edaed4ef8a1a7ac2","receivers":[{"name":"slack"}],"startsAt":"2026-05-18T02:01:11.872Z","status":{"inhibitedBy":[],"mutedBy":[],"silencedBy":[],"state":"active"},"updatedAt":"2026-05-20T04:58:41.875Z","generatorURL":"http://demo.prometheus.io:9090/graph?g0.expr=vector%281%29&g0.tab=1","labels":{"alertname":"Watchdog","environment":"demo-prometheus-io.c.macro-mile-203600.internal","severity":"warning"}}]
+        """
+
+    /// Empty alert list — drives the "all clear" green count badge in the
+    /// sidebar and the "No Alerts" state in the detail view.
+    static let empty = "[]"
+}

--- a/AlertmanagerUITests/FilterCRUDTests.swift
+++ b/AlertmanagerUITests/FilterCRUDTests.swift
@@ -12,14 +12,15 @@ import XCTest
 /// these tests first create an Alertmanager to satisfy that constraint.
 final class FilterCRUDTests: XCTestCase {
     var app: XCUIApplication!
-    /// Unique name for the helper alertmanager created in setUp.
-    var helperAMName: String = ""
+    /// Name of the helper alertmanager created in setUp. Stable across runs
+    /// because `-uiTestResetStore` gives each launch a fresh SwiftData store.
+    let helperAMName = "FT-AM"
 
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
+        app.launchArguments += ["-uiTestResetStore"]
         app.launch()
-        helperAMName = "FT-AM-\(Int(Date().timeIntervalSince1970))"
         createAlertmanager(named: helperAMName, url: "http://localhost:9093")
     }
 
@@ -43,9 +44,7 @@ final class FilterCRUDTests: XCTestCase {
         urlField.typeText(url)
 
         app.buttons["alertmanager-save-button"].click()
-        // Wait for the sheet to dismiss (save button disappears) rather than
-        // waiting for the sidebar row — the sidebar row can take a long time to
-        // render in a large store.
+        // Wait for the sheet to dismiss before returning.
         _ = app.textFields["alertmanager-name-field"].waitForNonExistence(timeout: 5)
     }
 
@@ -89,7 +88,7 @@ final class FilterCRUDTests: XCTestCase {
     func testCreateFilterAppearsInSidebar() throws {
         openAddFilterSheet()
         let nameField = waitForFilterForm()
-        let filterName = "FT-\(Int(Date().timeIntervalSince1970))"
+        let filterName = "FT"
         nameField.click()
         nameField.typeText(filterName)
 

--- a/AlertmanagerUITests/ImportExportRoundTripTests.swift
+++ b/AlertmanagerUITests/ImportExportRoundTripTests.swift
@@ -33,12 +33,14 @@ final class ImportExportRoundTripTests: XCTestCase {
             path: "Alertmanager-RoundTrip-\(UUID().uuidString).json")
 
         app = XCUIApplication()
-        app.launchArguments += [
-            "-uiTestResetStore",
-            "-uiTestSeedAlertmanagerURL", seededURL,
-            "-uiTestExportPath", roundTripPath.path,
-            "-uiTestImportPath", roundTripPath.path,
-        ]
+        app.launchArguments += ["-uiTestResetStore"]
+        // URL/path-shaped values travel via the environment instead of
+        // `launchArguments`. macOS 26 parses `-key value` argument pairs
+        // into `NSUserDefaults`, and URL/path-typed entries in that table
+        // prevent the app's main window from appearing at all.
+        app.launchEnvironment["UI_TEST_SEED_ALERTMANAGER_URL"] = seededURL
+        app.launchEnvironment["UI_TEST_EXPORT_PATH"] = roundTripPath.path
+        app.launchEnvironment["UI_TEST_IMPORT_PATH"] = roundTripPath.path
         app.launch()
     }
 

--- a/AlertmanagerUITests/ImportExportRoundTripTests.swift
+++ b/AlertmanagerUITests/ImportExportRoundTripTests.swift
@@ -12,13 +12,20 @@ import XCTest
 /// Reset Configuration menu command, and the file is then re-imported.
 /// The NSSavePanel / NSOpenPanel UI is bypassed via the
 /// `-uiTestExportPath` / `-uiTestImportPath` launch arguments so the test
-/// doesn't have to drive a system file dialog.
+/// doesn't have to drive a system file dialog, and the initial
+/// alertmanager is created via `-uiTestSeedAlertmanagerURL` to avoid
+/// driving the Add Alertmanager form (which was flaky on CI macOS runners).
 final class ImportExportRoundTripTests: XCTestCase {
     var app: XCUIApplication!
     /// Unique JSON file path used as both the export target and the
     /// subsequent import source. Lives in the test runner's temp dir,
     /// which the unsandboxed app can write to and the test can read.
     var roundTripPath: URL!
+
+    /// Name of the seeded alertmanager — must match the constant used by
+    /// `seedFromLaunchArgumentsIfNeeded` in `AlertmanagerApp.swift`.
+    let seededName = "Test AM"
+    let seededURL = "http://localhost:9093"
 
     override func setUpWithError() throws {
         continueAfterFailure = false
@@ -28,6 +35,7 @@ final class ImportExportRoundTripTests: XCTestCase {
         app = XCUIApplication()
         app.launchArguments += [
             "-uiTestResetStore",
+            "-uiTestSeedAlertmanagerURL", seededURL,
             "-uiTestExportPath", roundTripPath.path,
             "-uiTestImportPath", roundTripPath.path,
         ]
@@ -47,35 +55,17 @@ final class ImportExportRoundTripTests: XCTestCase {
         app.menuBarItems["Alertmanager"].click()
     }
 
-    /// Creates one alertmanager via the Add Alertmanager menu + form.
-    private func createAlertmanager(named name: String, url: String) {
-        openAlertmanagerMenu()
-        app.menuItems["Add Alertmanager"].click()
-
-        let nameField = app.textFields["alertmanager-name-field"]
-        XCTAssertTrue(nameField.waitForExistence(timeout: 5))
-        nameField.click()
-        nameField.typeText(name)
-
-        let urlField = app.textFields["alertmanager-url-field"]
-        urlField.click()
-        urlField.typeText(url)
-
-        app.buttons["alertmanager-save-button"].click()
-        // Wait for the sheet to dismiss before continuing.
-        _ = app.textFields["alertmanager-name-field"].waitForNonExistence(timeout: 5)
-    }
-
     // MARK: - Round trip
 
     @MainActor
     func testExportResetImportRoundTrip() throws {
-        // 1. Seed one alertmanager so there is something to export.
-        let name = "RoundTrip AM"
-        createAlertmanager(named: name, url: "http://localhost:9093")
-
-        let sidebarRow = app.buttons["sidebar-alertmanager-name-\(name)"]
-        XCTAssertTrue(sidebarRow.waitForExistence(timeout: 5))
+        // 1. The seed inserted a `Test AM` row at app launch. Wait for
+        // the corresponding sidebar entry so subsequent assertions have
+        // a stable target to track across reset and import.
+        let sidebarRow = app.descendants(matching: .button).matching(
+            NSPredicate(format: "identifier BEGINSWITH 'sidebar-alertmanager-name-\(seededName)'")
+        ).firstMatch
+        XCTAssertTrue(sidebarRow.waitForExistence(timeout: 10))
 
         // 2. Trigger Export — app writes the JSON file directly to
         // `roundTripPath` because of `-uiTestExportPath`.
@@ -92,8 +82,8 @@ final class ImportExportRoundTripTests: XCTestCase {
             JSONSerialization.jsonObject(with: exportData) as? [String: Any])
         let alertmanagers = try XCTUnwrap(json["alertmanagers"] as? [[String: Any]])
         XCTAssertEqual(alertmanagers.count, 1)
-        XCTAssertEqual(alertmanagers.first?["name"] as? String, name)
-        XCTAssertEqual(alertmanagers.first?["url"] as? String, "http://localhost:9093")
+        XCTAssertEqual(alertmanagers.first?["name"] as? String, seededName)
+        XCTAssertEqual(alertmanagers.first?["url"] as? String, seededURL)
 
         // 3. Trigger Reset and confirm the destructive action.
         openAlertmanagerMenu()

--- a/AlertmanagerUITests/ImportExportRoundTripTests.swift
+++ b/AlertmanagerUITests/ImportExportRoundTripTests.swift
@@ -1,0 +1,144 @@
+//
+//  ImportExportRoundTripTests.swift
+//  AlertmanagerUITests
+//
+
+import XCTest
+
+/// End-to-end test of the export → reset → import flow.
+///
+/// Exercises the real `ImportExportManager` code path: a configuration is
+/// serialized to a real JSON file on disk, the store is wiped via the
+/// Reset Configuration menu command, and the file is then re-imported.
+/// The NSSavePanel / NSOpenPanel UI is bypassed via the
+/// `-uiTestExportPath` / `-uiTestImportPath` launch arguments so the test
+/// doesn't have to drive a system file dialog.
+final class ImportExportRoundTripTests: XCTestCase {
+    var app: XCUIApplication!
+    /// Unique JSON file path used as both the export target and the
+    /// subsequent import source. Lives in the test runner's temp dir,
+    /// which the unsandboxed app can write to and the test can read.
+    var roundTripPath: URL!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        roundTripPath = FileManager.default.temporaryDirectory.appending(
+            path: "Alertmanager-RoundTrip-\(UUID().uuidString).json")
+
+        app = XCUIApplication()
+        app.launchArguments += [
+            "-uiTestResetStore",
+            "-uiTestExportPath", roundTripPath.path,
+            "-uiTestImportPath", roundTripPath.path,
+        ]
+        app.launch()
+    }
+
+    override func tearDownWithError() throws {
+        app?.terminate()
+        if let path = roundTripPath {
+            try? FileManager.default.removeItem(at: path)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func openAlertmanagerMenu() {
+        app.menuBarItems["Alertmanager"].click()
+    }
+
+    /// Creates one alertmanager via the Add Alertmanager menu + form.
+    private func createAlertmanager(named name: String, url: String) {
+        openAlertmanagerMenu()
+        app.menuItems["Add Alertmanager"].click()
+
+        let nameField = app.textFields["alertmanager-name-field"]
+        XCTAssertTrue(nameField.waitForExistence(timeout: 5))
+        nameField.click()
+        nameField.typeText(name)
+
+        let urlField = app.textFields["alertmanager-url-field"]
+        urlField.click()
+        urlField.typeText(url)
+
+        app.buttons["alertmanager-save-button"].click()
+        // Wait for the sheet to dismiss before continuing.
+        _ = app.textFields["alertmanager-name-field"].waitForNonExistence(timeout: 5)
+    }
+
+    // MARK: - Round trip
+
+    @MainActor
+    func testExportResetImportRoundTrip() throws {
+        // 1. Seed one alertmanager so there is something to export.
+        let name = "RoundTrip AM"
+        createAlertmanager(named: name, url: "http://localhost:9093")
+
+        let sidebarRow = app.buttons["sidebar-alertmanager-name-\(name)"]
+        XCTAssertTrue(sidebarRow.waitForExistence(timeout: 5))
+
+        // 2. Trigger Export — app writes the JSON file directly to
+        // `roundTripPath` because of `-uiTestExportPath`.
+        openAlertmanagerMenu()
+        app.menuItems["Export Configuration"].click()
+
+        let exportedAt = expectFileExists(at: roundTripPath, timeout: 5)
+        XCTAssertNotNil(exportedAt, "Export file was never written to \(roundTripPath.path)")
+
+        // Sanity-check the file is a valid JSON document containing the
+        // seeded alertmanager.
+        let exportData = try Data(contentsOf: roundTripPath)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: exportData) as? [String: Any])
+        let alertmanagers = try XCTUnwrap(json["alertmanagers"] as? [[String: Any]])
+        XCTAssertEqual(alertmanagers.count, 1)
+        XCTAssertEqual(alertmanagers.first?["name"] as? String, name)
+        XCTAssertEqual(alertmanagers.first?["url"] as? String, "http://localhost:9093")
+
+        // 3. Trigger Reset and confirm the destructive action.
+        openAlertmanagerMenu()
+        app.menuItems["Reset Configuration"].click()
+
+        // The confirmation dialog renders the destructive button as
+        // "Reset". macOS also surfaces a same-labeled control on the
+        // TouchBar, so match on the sheet's `action-button-1`
+        // identifier instead — that's the system-assigned id for the
+        // first non-cancel button in an alert/confirmation sheet.
+        let resetButton = app.sheets.firstMatch.buttons["action-button-1"]
+        XCTAssertTrue(resetButton.waitForExistence(timeout: 5))
+        resetButton.click()
+
+        // The sidebar row must disappear after reset.
+        XCTAssertTrue(sidebarRow.waitForNonExistence(timeout: 5))
+
+        // 4. Trigger Import — app reads from `roundTripPath` because of
+        // `-uiTestImportPath`.
+        openAlertmanagerMenu()
+        app.menuItems["Import Configuration"].click()
+
+        // Dismiss the "Import Complete" success alert. Same TouchBar
+        // duplicate caveat applies — scope to the sheet.
+        let okButton = app.sheets.firstMatch.buttons["action-button-1"]
+        XCTAssertTrue(okButton.waitForExistence(timeout: 5))
+        okButton.click()
+
+        // The previously-seeded row should reappear from the imported JSON.
+        XCTAssertTrue(sidebarRow.waitForExistence(timeout: 5))
+    }
+
+    // MARK: - Helpers
+
+    /// Polls `FileManager` for the given path. Returns the modification
+    /// date if the file appeared within `timeout`, otherwise `nil`.
+    private func expectFileExists(at url: URL, timeout: TimeInterval) -> Date? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if FileManager.default.fileExists(atPath: url.path) {
+                return (try? FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate])
+                    as? Date ?? Date()
+            }
+            Thread.sleep(forTimeInterval: 0.2)
+        }
+        return nil
+    }
+}

--- a/AlertmanagerUITests/ImportExportTests.swift
+++ b/AlertmanagerUITests/ImportExportTests.swift
@@ -12,6 +12,7 @@ final class ImportExportTests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
+        app.launchArguments += ["-uiTestResetStore"]
         app.launch()
     }
 

--- a/AlertmanagerUITests/SettingsTests.swift
+++ b/AlertmanagerUITests/SettingsTests.swift
@@ -12,6 +12,7 @@ final class SettingsTests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
+        app.launchArguments += ["-uiTestResetStore"]
         app.launch()
     }
 

--- a/AlertmanagerUITests/SmokeTests.swift
+++ b/AlertmanagerUITests/SmokeTests.swift
@@ -14,6 +14,7 @@ final class SmokeTests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
+        app.launchArguments += ["-uiTestResetStore"]
         app.launch()
     }
 


### PR DESCRIPTION
Each UI test launch now runs against a fresh, temp-dir SwiftData store
instead of the developer's real Application Support data, and gains a
set of hooks that lets tests exercise the real fetch + display paths
without standing up external infrastructure.

App-side launch-argument hooks (all no-ops outside UI tests):
  -uiTestResetStore           redirect the SQLite file to a unique temp
                              path so each launch starts empty
  -uiTestSeedAlertmanagerURL  pre-insert a single `Test AM` row pointing
                              at the given URL via `container.mainContext`
                              so display tests skip the form flow
  -uiTestExportPath           skip `NSSavePanel` and write the export JSON
                              directly to the path
  -uiTestImportPath           skip `NSOpenPanel` and read the import JSON
                              directly from the path

New tests:
  AlertDisplayTests           drives `FakeAlertmanagerServer` (an
                              `NWListener`-backed loopback HTTP server) to
                              cover the populated, empty, and 500 error
                              sidebar states plus the `AlertRowView`
                              rendering path
  ImportExportRoundTripTests  exports the configuration to a real JSON
                              file with a unique name, resets via the
                              menu command, and imports the same file
                              back to verify the round trip

Existing tests are cleaned up: the timestamp-based unique-name
workarounds in `AlertmanagerCRUDTests` / `FilterCRUDTests` are gone now
that each launch starts empty.

Infrastructure: the UI test runner is sandboxed by default, so the
loopback listener required adding `com.apple.security.network.server`
via a new `AlertmanagerUITests.entitlements` file wired into the test
target's `CODE_SIGN_ENTITLEMENTS` setting.