### PR TITLE
fix(filter): treat empty alertmanager selection as all alertmanagers

### DIFF
--- a/Alertmanager/MenuBarContentView.swift
+++ b/Alertmanager/MenuBarContentView.swift
@@ -45,8 +45,9 @@ struct MenuBarContentView: View {
     /// they originated from (needed for deep-link construction in
     /// `AlertRowView`).
     ///
-    /// The filter's `selectedAlertmanagerIDs` narrows the source set;
-    /// an empty list means "all alertmanagers". Alerts that share a
+    /// The filter's `selectedAlertmanagerIDs` narrows the source set; an
+    /// empty list means "all alertmanagers" (the shared semantic from
+    /// `Filter.includesAlertmanager(withID:)`). Alerts that share a
     /// `fingerprint` across multiple alertmanagers are deduplicated; the
     /// alertmanager that appears earliest in sidebar order wins and
     /// determines which entity is paired with the surviving alert (so
@@ -55,13 +56,8 @@ struct MenuBarContentView: View {
     private var filteredAlerts: [(alert: GettableAlert, alertmanager: Alertmanager)] {
         guard let filter = selectedFilter else { return [] }
 
-        let relevantAlertmanagers: [Alertmanager]
-        if filter.selectedAlertmanagerIDs.isEmpty {
-            relevantAlertmanagers = alertmanagers
-        } else {
-            relevantAlertmanagers = alertmanagers.filter {
-                filter.selectedAlertmanagerIDs.contains($0.id)
-            }
+        let relevantAlertmanagers = alertmanagers.filter {
+            filter.includesAlertmanager(withID: $0.id)
         }
 
         var result: [(GettableAlert, Alertmanager)] = []

--- a/Alertmanager/Models/Filter.swift
+++ b/Alertmanager/Models/Filter.swift
@@ -60,7 +60,9 @@ final class Filter {
     var name: String
 
     /// IDs of `Alertmanager` entries this filter applies to. An empty array
-    /// is interpreted by callers as "all alertmanagers".
+    /// means "all alertmanagers" — use `includesAlertmanager(withID:)`
+    /// instead of testing membership directly so that semantic is applied
+    /// consistently.
     var selectedAlertmanagerIDs: [UUID]
 
     /// Alert states to include (e.g. `.active`, `.suppressed`,
@@ -150,6 +152,18 @@ final class Filter {
         self.sortOrder = sortOrder
         self.notificationsEnabled = notificationsEnabled
         self.labelMatchers = labelMatchers
+    }
+
+    /// Whether this filter sources alerts from the given alertmanager.
+    ///
+    /// An empty `selectedAlertmanagerIDs` means "all alertmanagers".
+    /// Centralised here so every alert surface (sidebar badge, detail
+    /// view, menu bar popup, notifications) agrees on that semantic.
+    ///
+    /// - Parameter id: The `Alertmanager.id` to test.
+    /// - Returns: `true` when the filter covers the alertmanager.
+    func includesAlertmanager(withID id: UUID) -> Bool {
+        selectedAlertmanagerIDs.isEmpty || selectedAlertmanagerIDs.contains(id)
     }
 
     /// Returns the subset of `alerts` that satisfy every configured

--- a/Alertmanager/Services/AlertAggregator.swift
+++ b/Alertmanager/Services/AlertAggregator.swift
@@ -23,7 +23,8 @@ enum AlertAggregator {
     /// produced by multiple alertmanagers the first one in sidebar order
     /// wins and later duplicates are dropped. `filter.selectedAlertmanagerIDs`
     /// is treated as an unordered set membership filter rather than the
-    /// iteration order.
+    /// iteration order; an empty selection means "all alertmanagers"
+    /// (see `Filter.includesAlertmanager(withID:)`).
     ///
     /// - Parameters:
     ///   - filter: The filter whose `selectedAlertmanagerIDs` and predicates
@@ -40,11 +41,11 @@ enum AlertAggregator {
         from cache: [UUID: [GettableAlert]],
         orderedAlertmanagerIDs: [UUID]
     ) -> [GettableAlert] {
-        let selected = Set(filter.selectedAlertmanagerIDs)
         var allAlerts: [GettableAlert] = []
         var seenFingerprints: Set<String> = []
 
-        for alertmanagerID in orderedAlertmanagerIDs where selected.contains(alertmanagerID) {
+        for alertmanagerID in orderedAlertmanagerIDs
+        where filter.includesAlertmanager(withID: alertmanagerID) {
             let cached = cache[alertmanagerID] ?? []
             for alert in cached {
                 if !seenFingerprints.contains(alert.fingerprint) {

--- a/Alertmanager/Views/FilterDetailView.swift
+++ b/Alertmanager/Views/FilterDetailView.swift
@@ -198,12 +198,12 @@ struct FilterDetailView: View {
     /// which subscribes to `.alertsDidUpdate` and checks all filters
     /// independently of which view is visible.
     private func updateAlerts() {
-        let selected = Set(filter.selectedAlertmanagerIDs)
         var allAlerts: [GettableAlert] = []
         var seenFingerprints: Set<String> = []
         var anyLoading = false
 
-        for alertmanager in alertmanagers where selected.contains(alertmanager.id) {
+        for alertmanager in alertmanagers
+        where filter.includesAlertmanager(withID: alertmanager.id) {
             let alerts = AlertsManager.shared.alertsByAlertmanager[alertmanager.id] ?? []
 
             for alert in alerts {
@@ -225,12 +225,12 @@ struct FilterDetailView: View {
     }
 
     /// Forces an out-of-band refresh on every alertmanager referenced by
-    /// the filter, bypassing the polling cadence.
+    /// the filter, bypassing the polling cadence. An empty selection
+    /// refreshes all alertmanagers.
     private func refreshAlerts() {
-        for alertmanagerId in filter.selectedAlertmanagerIDs {
-            if let alertmanager = alertmanagers.first(where: { $0.id == alertmanagerId }) {
-                AlertsManager.shared.refresh(alertmanager: alertmanager)
-            }
+        for alertmanager in alertmanagers
+        where filter.includesAlertmanager(withID: alertmanager.id) {
+            AlertsManager.shared.refresh(alertmanager: alertmanager)
         }
     }
 
@@ -244,8 +244,8 @@ struct FilterDetailView: View {
     /// nothing matches (which can happen briefly when caches are still being
     /// populated).
     private func findAlertmanager(for alert: GettableAlert) -> Alertmanager? {
-        let selected = Set(filter.selectedAlertmanagerIDs)
-        for alertmanager in alertmanagers where selected.contains(alertmanager.id) {
+        for alertmanager in alertmanagers
+        where filter.includesAlertmanager(withID: alertmanager.id) {
             let alertmanagerAlerts =
                 AlertsManager.shared.alertsByAlertmanager[alertmanager.id] ?? []
             if alertmanagerAlerts.contains(where: { $0.id == alert.id }) {

--- a/AlertmanagerTests/AlertAggregatorTests.swift
+++ b/AlertmanagerTests/AlertAggregatorTests.swift
@@ -157,6 +157,29 @@ struct AlertAggregatorTests {
         #expect(result[0].fingerprint == "active")
     }
 
+    @Test("Empty selection means all alertmanagers")
+    func emptySelectionMeansAllAlertmanagers() {
+        let id1 = UUID()
+        let id2 = UUID()
+        let filter = Filter(
+            name: "f",
+            selectedAlertmanagerIDs: [],
+            states: []
+        )
+        let cache: [UUID: [GettableAlert]] = [
+            id1: [makeAlert(fingerprint: "a1")],
+            id2: [makeAlert(fingerprint: "b1")],
+        ]
+
+        let result = AlertAggregator.alerts(
+            for: filter,
+            from: cache,
+            orderedAlertmanagerIDs: [id1, id2]
+        )
+        let fps = Set(result.map(\.fingerprint))
+        #expect(fps == ["a1", "b1"])
+    }
+
     @Test("Returns empty array when filter references an unknown alertmanager ID")
     func unknownAlertmanagerIDReturnsEmpty() {
         let filter = Filter(
@@ -182,5 +205,25 @@ struct AlertAggregatorTests {
             orderedAlertmanagerIDs: [id]
         )
         #expect(result.isEmpty)
+    }
+}
+
+// MARK: - Filter.includesAlertmanager tests
+
+@Suite("Filter.includesAlertmanager")
+struct FilterIncludesAlertmanagerTests {
+
+    @Test("Empty selection includes every alertmanager")
+    func emptySelectionIncludesAll() {
+        let filter = Filter(name: "f", selectedAlertmanagerIDs: [])
+        #expect(filter.includesAlertmanager(withID: UUID()))
+    }
+
+    @Test("Non-empty selection includes only listed alertmanagers")
+    func nonEmptySelectionIsMembershipTest() {
+        let selected = UUID()
+        let filter = Filter(name: "f", selectedAlertmanagerIDs: [selected])
+        #expect(filter.includesAlertmanager(withID: selected))
+        #expect(!filter.includesAlertmanager(withID: UUID()))
     }
 }


### PR DESCRIPTION
Filter.selectedAlertmanagerIDs documents an empty array as "all
alertmanagers" and the menu bar popup honors that, but AlertAggregator
and FilterDetailView silently treated it as "none". A filter without
alertmanager references — reachable via configuration import, which
drops alertmanager names it cannot resolve — showed alerts in the menu
bar while the sidebar badge stayed at 0, the detail view stayed empty,
and notifications never fired.

Centralize the semantic in Filter.includesAlertmanager(withID:) and
use it from AlertAggregator, FilterDetailView, and MenuBarContentView
so every alert surface agrees.