### PR TITLE
fix(notifications): don't stall baselines on failing alertmanagers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,9 +100,12 @@ AlertmanagerUITests/        XCTest — driven via accessibilityIdentifiers.
   2. `NotificationService` subscribes to `.alertsDidUpdate` and re-evaluates
      **every** filter on every fetch (not just the one currently visible).
   3. First fetch for a filter is a silent **baseline** — no notifications. A
-     filter is only baselined once all its referenced AMs have completed at
-     least one fetch (`AlertsManager.lastRefreshByAlertmanager[…] != nil`), so
-     partial data doesn't seed a bad baseline.
+     filter is only baselined once all the AMs it covers have completed at
+     least one fetch attempt — successful or failed
+     (`AlertsManager.hasCompletedFetchByAlertmanager`) — so partial data
+     doesn't seed a bad baseline, while a permanently failing AM can't block
+     notifications for the healthy ones. Stale AM IDs that no longer resolve
+     are ignored; an empty selection covers all AMs.
   4. 32 notification categories (`ALERT_0` … `ALERT_31`) are pre-registered;
      each notification picks the one whose action set matches the URLs it
      actually has (bitmask: source=1, silence=2, runbook=4, dashboard=8,

--- a/Alertmanager/Services/AlertsManager.swift
+++ b/Alertmanager/Services/AlertsManager.swift
@@ -91,6 +91,13 @@ class AlertsManager {
     /// Timestamp of the most recent successful fetch per alertmanager.
     var lastRefreshByAlertmanager: [UUID: Date] = [:]
 
+    /// `true` once at least one fetch attempt — successful or failed —
+    /// has completed for the alertmanager. Unlike
+    /// `lastRefreshByAlertmanager`, this is also set when a fetch errors,
+    /// so consumers (e.g. `NotificationService` baselining) can
+    /// distinguish "never fetched yet" from "fetched but failing".
+    var hasCompletedFetchByAlertmanager: [UUID: Bool] = [:]
+
     /// `true` while a fetch is in flight for the given alertmanager.
     var isLoadingByAlertmanager: [UUID: Bool] = [:]
 
@@ -197,6 +204,7 @@ class AlertsManager {
             }
 
             isLoadingByAlertmanager[alertmanager.id] = false
+            hasCompletedFetchByAlertmanager[alertmanager.id] = true
             inFlightTasks[alertmanager.id] = nil
 
             // Broadcast the change. Listeners can scope by reading

--- a/Alertmanager/Services/NotificationService.swift
+++ b/Alertmanager/Services/NotificationService.swift
@@ -231,11 +231,16 @@ class NotificationService: NSObject {
     /// Diffs the current alert set against the previously seen set for
     /// `filter` and notifies on additions.
     ///
-    /// - First call for a given filter id where all referenced alertmanagers
-    ///   have completed at least one fetch: records the baseline silently.
-    ///   If some alertmanagers haven't fetched yet the call is skipped
-    ///   entirely so partial data doesn't contaminate the baseline and
-    ///   cause spurious notifications once the remaining fetches land.
+    /// - First call for a given filter id where all covered alertmanagers
+    ///   have completed at least one fetch attempt (successful or failed):
+    ///   records the baseline silently. If some alertmanagers haven't
+    ///   fetched yet the call is skipped entirely so partial data doesn't
+    ///   contaminate the baseline and cause spurious notifications once
+    ///   the remaining fetches land. An empty
+    ///   `filter.selectedAlertmanagerIDs` covers all alertmanagers, and
+    ///   IDs that no longer resolve to a known alertmanager (deleted
+    ///   entries) are ignored — both would otherwise gate the baseline on
+    ///   alertmanagers that can never report a fetch.
     /// - Subsequent calls: any fingerprint not in the previous set is
     ///   considered new, and a notification is dispatched per new alert.
     /// - The seen-set is then replaced with `currentFingerprints` (alerts
@@ -253,12 +258,23 @@ class NotificationService: NSObject {
     func checkForNewAlerts(filter: Filter, alerts: [GettableAlert], alertmanagers: [Alertmanager]) {
         guard filter.notificationsEnabled else { return }
 
-        // Wait until every alertmanager referenced by this filter has
-        // completed at least one fetch. This prevents a race where the
-        // first alertmanager to finish sets a partial baseline; when the
-        // second finishes its alerts would all appear "new".
-        let allFetched = filter.selectedAlertmanagerIDs.allSatisfy {
-            AlertsManager.shared.lastRefreshByAlertmanager[$0] != nil
+        // Wait until every alertmanager covered by this filter has
+        // completed at least one fetch attempt. This prevents a race where
+        // the first alertmanager to finish sets a partial baseline; when
+        // the second finishes its alerts would all appear "new". Gating on
+        // completed *attempts* (rather than successes) keeps one
+        // permanently failing alertmanager from blocking notifications for
+        // the healthy ones forever. The covered set is resolved against
+        // the known alertmanagers so stale IDs left behind by deleted
+        // entries — which can never fetch again — don't stall the
+        // baseline either; an empty selection covers all alertmanagers.
+        let knownIDs = alertmanagers.map(\.id)
+        let coveredIDs =
+            filter.selectedAlertmanagerIDs.isEmpty
+            ? knownIDs
+            : filter.selectedAlertmanagerIDs.filter { knownIDs.contains($0) }
+        let allFetched = coveredIDs.allSatisfy {
+            AlertsManager.shared.hasCompletedFetchByAlertmanager[$0] == true
         }
         guard allFetched else { return }
 


### PR DESCRIPTION
checkForNewAlerts only baselined a filter once every referenced
alertmanager had a lastRefresh timestamp, which is set exclusively on
successful fetches. A permanently failing alertmanager (e.g. bad
credentials) or a stale ID left behind by a deleted alertmanager kept
the filter unbaselined forever, silently disabling notifications for
the remaining healthy alertmanagers. An empty selection also passed
the gate trivially instead of waiting for the alertmanagers it
actually covers.

Track completed fetch attempts (success or failure) in AlertsManager
and gate baselines on that, ignore referenced IDs that no longer
resolve to a known alertmanager, and treat an empty selection as
covering all alertmanagers, matching the documented filter semantics.