### PR TITLE
fix(import): skip filters that already exist on re-import

### DIFF
--- a/Alertmanager/ContentView.swift
+++ b/Alertmanager/ContentView.swift
@@ -400,7 +400,8 @@ struct ContentView: View {
             let result = try ImportExportManager.importData(
                 from: data,
                 modelContext: modelContext,
-                existingAlertmanagers: alertmanagers
+                existingAlertmanagers: alertmanagers,
+                existingFilters: filters
             )
 
             var message =

--- a/Alertmanager/Services/ImportExportManager.swift
+++ b/Alertmanager/Services/ImportExportManager.swift
@@ -230,8 +230,11 @@ class ImportExportManager {
     ///   `(name, url)` pair; otherwise inserted. A name → id map is
     ///   built (using either new or existing ids) so filters can be
     ///   resolved.
-    /// - **Filters**: always inserted; alertmanager names that don't
-    ///   resolve are dropped from `selectedAlertmanagerIDs`.
+    /// - **Filters**: skipped if an existing filter has the same name;
+    ///   otherwise inserted. Alertmanager names that don't resolve are
+    ///   dropped from `selectedAlertmanagerIDs`. Together with the
+    ///   alertmanager dedup this makes re-importing the same file a
+    ///   no-op.
     /// - **Settings**: when present, overwrite the current settings;
     ///   the menu-bar filter is re-resolved by name against the just
     ///   imported set.
@@ -239,7 +242,8 @@ class ImportExportManager {
     /// - Returns: counts of newly inserted alertmanagers and filters,
     ///   plus a flag indicating whether settings were restored.
     static func importData(
-        from data: Data, modelContext: ModelContext, existingAlertmanagers: [Alertmanager]
+        from data: Data, modelContext: ModelContext, existingAlertmanagers: [Alertmanager],
+        existingFilters: [Filter]
     ) throws -> (alertmanagers: Int, filters: Int, settingsRestored: Bool) {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
@@ -274,9 +278,12 @@ class ImportExportManager {
                 importedAlertmanagersCount += 1
             } else {
                 // Already present — record the existing id so filters
-                // can still resolve their references.
+                // can still resolve their references. Match on the same
+                // `(name, url)` pair as the `exists` check above; a
+                // name-only lookup could map to a different entry that
+                // happens to share the name.
                 if let existing = existingAlertmanagers.first(where: {
-                    $0.name == exportAlertmanager.name
+                    $0.name == exportAlertmanager.name && $0.url == exportAlertmanager.url
                 }) {
                     alertmanagerNameToId[exportAlertmanager.name] = existing.id
                 }
@@ -289,6 +296,15 @@ class ImportExportManager {
         var filterNameToId: [String: UUID] = [:]
 
         for exportFilter in exportData.filters {
+            // De-duplicate against existing filters by name — mirroring
+            // the alertmanager dedup above — so re-importing the same
+            // file doesn't multiply filters. The existing id is still
+            // recorded so the menu-bar filter setting can resolve.
+            if let existing = existingFilters.first(where: { $0.name == exportFilter.name }) {
+                filterNameToId[exportFilter.name] = existing.id
+                continue
+            }
+
             // Drop alertmanager references whose names are unknown in
             // this store. (`compactMap` silently filters them out.)
             let alertmanagerIds = exportFilter.alertmanagerNames.compactMap { name in

--- a/AlertmanagerTests/ImportExportManagerTests.swift
+++ b/AlertmanagerTests/ImportExportManagerTests.swift
@@ -99,7 +99,8 @@ struct ImportExportRoundTripTests {
         let result = try ImportExportManager.importData(
             from: data,
             modelContext: freshContext,
-            existingAlertmanagers: []
+            existingAlertmanagers: [],
+            existingFilters: []
         )
 
         #expect(result.alertmanagers == 2)
@@ -134,7 +135,8 @@ struct ImportExportRoundTripTests {
         let result = try ImportExportManager.importData(
             from: data,
             modelContext: freshContext,
-            existingAlertmanagers: []
+            existingAlertmanagers: [],
+            existingFilters: []
         )
 
         #expect(result.filters == 1)
@@ -167,7 +169,8 @@ struct ImportExportRoundTripTests {
         let r1 = try ImportExportManager.importData(
             from: data,
             modelContext: freshContext,
-            existingAlertmanagers: []
+            existingAlertmanagers: [],
+            existingFilters: []
         )
         #expect(r1.alertmanagers == 1)
 
@@ -177,11 +180,59 @@ struct ImportExportRoundTripTests {
         let r2 = try ImportExportManager.importData(
             from: data,
             modelContext: freshContext,
-            existingAlertmanagers: afterFirst
+            existingAlertmanagers: afterFirst,
+            existingFilters: []
         )
         #expect(r2.alertmanagers == 0)
 
         let afterSecond = try freshContext.fetch(FetchDescriptor<Alertmanager>())
+        #expect(afterSecond.count == 1)
+    }
+
+    @Test("Importing the same file twice does not duplicate filters")
+    @MainActor
+    func noFilterDuplicatesOnSecondImport() throws {
+        let container = try makeInMemoryContainer()
+        let context = ModelContext(container)
+
+        let am = makeAlertmanager(name: "Prod", url: "https://prod.example.com")
+        context.insert(am)
+        let filter = Filter(
+            name: "Critical",
+            selectedAlertmanagerIDs: [am.id],
+            states: [.active]
+        )
+        context.insert(filter)
+        try context.save()
+
+        let data = try #require(
+            ImportExportManager.exportData(alertmanagers: [am], filters: [filter]))
+
+        let freshContainer = try makeInMemoryContainer()
+        let freshContext = ModelContext(freshContainer)
+
+        // First import into an empty store inserts the filter.
+        let r1 = try ImportExportManager.importData(
+            from: data,
+            modelContext: freshContext,
+            existingAlertmanagers: [],
+            existingFilters: []
+        )
+        #expect(r1.filters == 1)
+
+        let afterFirstAMs = try freshContext.fetch(FetchDescriptor<Alertmanager>())
+        let afterFirstFilters = try freshContext.fetch(FetchDescriptor<Filter>())
+
+        // Second import — the same-named filter must be skipped.
+        let r2 = try ImportExportManager.importData(
+            from: data,
+            modelContext: freshContext,
+            existingAlertmanagers: afterFirstAMs,
+            existingFilters: afterFirstFilters
+        )
+        #expect(r2.filters == 0)
+
+        let afterSecond = try freshContext.fetch(FetchDescriptor<Filter>())
         #expect(afterSecond.count == 1)
     }
 
@@ -212,7 +263,8 @@ struct ImportExportRoundTripTests {
         let result = try ImportExportManager.importData(
             from: exportJSON,
             modelContext: freshContext,
-            existingAlertmanagers: []
+            existingAlertmanagers: [],
+            existingFilters: []
         )
         #expect(result.filters == 1)
 
@@ -246,7 +298,8 @@ struct ImportExportRoundTripTests {
         try ImportExportManager.importData(
             from: exportJSON,
             modelContext: freshContext,
-            existingAlertmanagers: []
+            existingAlertmanagers: [],
+            existingFilters: []
         )
 
         let imported = try freshContext.fetch(FetchDescriptor<Filter>())
@@ -283,7 +336,8 @@ struct ImportExportRoundTripTests {
         try ImportExportManager.importData(
             from: exportJSON,
             modelContext: freshContext,
-            existingAlertmanagers: []
+            existingAlertmanagers: [],
+            existingFilters: []
         )
 
         let imported = try freshContext.fetch(FetchDescriptor<Filter>())
@@ -314,7 +368,8 @@ struct ImportExportRoundTripTests {
         try ImportExportManager.importData(
             from: exportJSON,
             modelContext: freshContext,
-            existingAlertmanagers: []
+            existingAlertmanagers: [],
+            existingFilters: []
         )
 
         let ams = try freshContext.fetch(FetchDescriptor<Alertmanager>())
@@ -347,7 +402,8 @@ struct ImportExportRoundTripTests {
         try ImportExportManager.importData(
             from: data,
             modelContext: freshContext,
-            existingAlertmanagers: []
+            existingAlertmanagers: [],
+            existingFilters: []
         )
 
         let imported = try freshContext.fetch(FetchDescriptor<Alertmanager>())
@@ -376,7 +432,8 @@ struct ImportExportRoundTripTests {
         let result = try ImportExportManager.importData(
             from: exportJSON,
             modelContext: freshContext,
-            existingAlertmanagers: []
+            existingAlertmanagers: [],
+            existingFilters: []
         )
         #expect(result.settingsRestored == true)
     }
@@ -399,7 +456,8 @@ struct ImportExportRoundTripTests {
         let result = try ImportExportManager.importData(
             from: exportJSON,
             modelContext: freshContext,
-            existingAlertmanagers: []
+            existingAlertmanagers: [],
+            existingFilters: []
         )
         #expect(result.settingsRestored == false)
     }


### PR DESCRIPTION
Alertmanagers were deduplicated by (name, url) on import, but filters
were inserted unconditionally, so re-importing the same export file
doubled every filter. Filters are now matched by name against the
existing store and skipped, with the existing ID still recorded so the
menu-bar filter setting resolves — making re-import a full no-op as
the alertmanager dedup already promised.

Also match the existing-alertmanager ID lookup on (name, url) instead
of name only; with two same-named entries the lookup could previously
map imported filter references to the wrong alertmanager.