### PR TITLE
fix(alerts): clear cached state when monitoring stops

### DIFF
--- a/Alertmanager/Services/AlertsManager.swift
+++ b/Alertmanager/Services/AlertsManager.swift
@@ -166,6 +166,7 @@ class AlertsManager {
         lastRefreshByAlertmanager[alertmanager.id] = nil
         isLoadingByAlertmanager[alertmanager.id] = nil
         errorByAlertmanager[alertmanager.id] = nil
+        hasCompletedFetchByAlertmanager[alertmanager.id] = nil
     }
 
     /// Triggers a one-shot out-of-band fetch without disturbing the

--- a/Alertmanager/Services/AlertsManager.swift
+++ b/Alertmanager/Services/AlertsManager.swift
@@ -140,15 +140,25 @@ class AlertsManager {
         refreshTimers[alertmanager.id] = timer
     }
 
-    /// Stops polling for `alertmanager` and cancels any in-flight fetch.
-    /// Safe to call when no timer is installed. Should be called before
-    /// deleting the model so timer callbacks don't fire against a deleted
-    /// entity.
+    /// Stops polling for `alertmanager`, cancels any in-flight fetch, and
+    /// clears all cached state for it. Safe to call when no timer is
+    /// installed. Should be called before deleting the model so timer
+    /// callbacks don't fire against a deleted entity and its alerts,
+    /// errors, and loading flags don't linger in the caches forever.
     func stopMonitoring(alertmanager: Alertmanager) {
         refreshTimers[alertmanager.id]?.invalidate()
         refreshTimers[alertmanager.id] = nil
         inFlightTasks[alertmanager.id]?.cancel()
         inFlightTasks[alertmanager.id] = nil
+
+        // Drop the per-alertmanager caches. The entries would otherwise
+        // accumulate for every alertmanager ever deleted during the
+        // app's lifetime. The cancelled fetch task bails out before
+        // writing (see `fetchAlerts`), so it cannot resurrect them.
+        alertsByAlertmanager[alertmanager.id] = nil
+        lastRefreshByAlertmanager[alertmanager.id] = nil
+        isLoadingByAlertmanager[alertmanager.id] = nil
+        errorByAlertmanager[alertmanager.id] = nil
     }
 
     /// Triggers a one-shot out-of-band fetch without disturbing the
@@ -187,11 +197,19 @@ class AlertsManager {
 
             do {
                 let fetchedAlerts = try await service.fetchAlerts(for: alertmanager)
+                // A cancelled fetch means `stopMonitoring` ran (the entity
+                // is being deleted) and already cleared the caches — bail
+                // out before any write resurrects entries for it.
+                guard !Task.isCancelled else { return }
                 alertsByAlertmanager[alertmanager.id] = fetchedAlerts.sorted {
                     $0.startsAt > $1.startsAt
                 }
                 lastRefreshByAlertmanager[alertmanager.id] = Date()
             } catch {
+                // Same cancellation guard as above: URLSession surfaces a
+                // cancelled task as an error, which would otherwise be
+                // recorded in `errorByAlertmanager`.
+                guard !Task.isCancelled else { return }
                 errorByAlertmanager[alertmanager.id] = error.localizedDescription
                 print("Error fetching alerts for alertmanager \(alertmanager.name): \(error)")
             }

--- a/AlertmanagerTests/AlertsManagerTests.swift
+++ b/AlertmanagerTests/AlertsManagerTests.swift
@@ -40,6 +40,7 @@ struct AlertsManagerStopMonitoringTests {
         manager.lastRefreshByAlertmanager[alertmanager.id] = Date()
         manager.isLoadingByAlertmanager[alertmanager.id] = false
         manager.errorByAlertmanager[alertmanager.id] = "boom"
+        manager.hasCompletedFetchByAlertmanager[alertmanager.id] = true
 
         manager.stopMonitoring(alertmanager: alertmanager)
 
@@ -47,6 +48,7 @@ struct AlertsManagerStopMonitoringTests {
         #expect(manager.lastRefreshByAlertmanager[alertmanager.id] == nil)
         #expect(manager.isLoadingByAlertmanager[alertmanager.id] == nil)
         #expect(manager.errorByAlertmanager[alertmanager.id] == nil)
+        #expect(manager.hasCompletedFetchByAlertmanager[alertmanager.id] == nil)
     }
 
     @Test("Leaves other alertmanagers' caches untouched")

--- a/AlertmanagerTests/AlertsManagerTests.swift
+++ b/AlertmanagerTests/AlertsManagerTests.swift
@@ -1,0 +1,70 @@
+//
+//  AlertsManagerTests.swift
+//  AlertmanagerTests
+//
+
+import Foundation
+import Testing
+
+@testable import Alertmanager
+
+// MARK: - Helpers
+
+private func makeAlert(fingerprint: String) -> GettableAlert {
+    GettableAlert(
+        annotations: [:],
+        receivers: [],
+        fingerprint: fingerprint,
+        startsAt: Date(),
+        updatedAt: Date(),
+        endsAt: Date(),
+        status: AlertStatus(state: .active, silencedBy: [], inhibitedBy: []),
+        labels: [:],
+        generatorURL: nil
+    )
+}
+
+// MARK: - AlertsManager.stopMonitoring
+
+@Suite("AlertsManager.stopMonitoring")
+struct AlertsManagerStopMonitoringTests {
+
+    @Test("Clears all cached state for the alertmanager")
+    @MainActor
+    func clearsCachedState() {
+        let manager = AlertsManager.shared
+        let alertmanager = Alertmanager(name: "Doomed", url: "http://doomed.example.com")
+
+        // Seed every per-alertmanager cache as a completed fetch would.
+        manager.alertsByAlertmanager[alertmanager.id] = [makeAlert(fingerprint: "fp1")]
+        manager.lastRefreshByAlertmanager[alertmanager.id] = Date()
+        manager.isLoadingByAlertmanager[alertmanager.id] = false
+        manager.errorByAlertmanager[alertmanager.id] = "boom"
+
+        manager.stopMonitoring(alertmanager: alertmanager)
+
+        #expect(manager.alertsByAlertmanager[alertmanager.id] == nil)
+        #expect(manager.lastRefreshByAlertmanager[alertmanager.id] == nil)
+        #expect(manager.isLoadingByAlertmanager[alertmanager.id] == nil)
+        #expect(manager.errorByAlertmanager[alertmanager.id] == nil)
+    }
+
+    @Test("Leaves other alertmanagers' caches untouched")
+    @MainActor
+    func leavesOtherEntriesAlone() {
+        let manager = AlertsManager.shared
+        let doomed = Alertmanager(name: "Doomed", url: "http://doomed.example.com")
+        let survivor = Alertmanager(name: "Survivor", url: "http://survivor.example.com")
+
+        manager.alertsByAlertmanager[doomed.id] = [makeAlert(fingerprint: "fp1")]
+        manager.alertsByAlertmanager[survivor.id] = [makeAlert(fingerprint: "fp2")]
+
+        manager.stopMonitoring(alertmanager: doomed)
+
+        #expect(manager.alertsByAlertmanager[doomed.id] == nil)
+        #expect(manager.alertsByAlertmanager[survivor.id]?.count == 1)
+
+        // Clean up the shared singleton so other suites see no residue.
+        manager.stopMonitoring(alertmanager: survivor)
+    }
+}


### PR DESCRIPTION
stopMonitoring only invalidated the timer and cancelled the in-flight
task. The per-alertmanager alert, error, loading, and last-refresh
cache entries survived deletion, accumulating for every alertmanager
ever removed during the app's lifetime.

Clear the caches in stopMonitoring and bail out of a cancelled fetch
task before it writes: the catch path previously recorded the
cancellation as a fetch error, resurrecting the just-removed entries
when a deletion raced an in-flight fetch.

---

fix(alerts): drop completed-fetch marker when monitoring stops

hasCompletedFetchByAlertmanager (added on main for notification
baselining after this branch was cut) is per-alertmanager state like
the other caches, so stopMonitoring clears it too. The cancellation
guards in fetchAlerts already return before the marker is written, so
a deletion racing an in-flight fetch cannot resurrect it either.