### PR TITLE
chore: clean up duplication, stale docs, dead code, and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,8 +70,11 @@ Alertmanager/
                                local UNNotifications with deep-link actions.
     AlertAggregator.swift   Pure helper: collect+dedupe+filter from cache.
     AlertDeepLinks.swift    Pure helper: source/silence/dashboard/panel URLs.
+    AlertMarkdown.swift     Pure helper: alert → markdown snippet for copying.
     SettingsManager.swift   @Published wrapper around UserDefaults.
     ImportExportManager.swift  JSON v1.0 export/import; references by name.
+    UpdateCheckService.swift   Singleton. One-shot GitHub release probe that
+                               feeds the in-app update banner.
   Views/                    SwiftUI views (form sheets, detail panes, rows).
 AlertmanagerTests/          Swift Testing — model + service logic.
 AlertmanagerUITests/        XCTest — driven via accessibilityIdentifiers.
@@ -89,11 +92,14 @@ AlertmanagerUITests/        XCTest — driven via accessibilityIdentifiers.
   call from multiple `.onAppear` handlers — it replaces any existing timer.
   Concurrent fetches for the same AM are deduplicated via `inFlightTasks`.
 - **Two backend shapes**: a "standard" Prometheus Alertmanager hits
-  `/api/v2/alerts` directly; a "Grafana" entry iterates over
-  `grafanaAlertmanagers` (datasource names) and hits
-  `/api/alertmanager/{name}/api/v2/alerts`. Every alert returned in Grafana mode
-  is tagged with `grafanaAlertmanagerSource = name` and that tag must be
-  preserved end-to-end so silence/dashboard deep-links target the right backend.
+  `/api/v2/alerts` directly; a "Grafana" entry queries the single datasource
+  UID stored in `grafanaAlertmanager` via
+  `/api/alertmanager/{uid}/api/v2/alerts`. Alerts are **not** tagged with
+  their source — views and `NotificationService` re-resolve the producing AM
+  by scanning the per-AM caches (`AlertAggregator.alertsWithSources`,
+  `resolveAlertmanager`). Grafana silence deep-links need the datasource
+  *name*, which `AlertmanagerService.resolveSilenceURL` resolves from the
+  UID at link-build time (the built-in `"grafana"` value is used verbatim).
 - **Notification flow**:
   1. `AlertmanagerApp.onAppear` calls
      `NotificationService.shared.configure(with:)`.
@@ -106,8 +112,9 @@ AlertmanagerUITests/        XCTest — driven via accessibilityIdentifiers.
      doesn't seed a bad baseline, while a permanently failing AM can't block
      notifications for the healthy ones. Stale AM IDs that no longer resolve
      are ignored; an empty selection covers all AMs.
-  4. 32 notification categories (`ALERT_0` … `ALERT_31`) are pre-registered;
-     each notification picks the one whose action set matches the URLs it
+  4. 31 notification categories (`ALERT_1` … `ALERT_31`) are pre-registered
+     (`ALERT_0` — no actions — is deliberately left unregistered); each
+     notification picks the one whose action set matches the URLs it
      actually has (bitmask: source=1, silence=2, runbook=4, dashboard=8,
      panel=16). When adding a new deep-link action, update both
      `registerNotificationCategories` _and_ `categoryIdentifier(for:)`.
@@ -171,9 +178,10 @@ AlertmanagerUITests/        XCTest — driven via accessibilityIdentifiers.
 - **Don't `union` the seen-set** in `NotificationService.checkForNewAlerts`.
   Replacing (not unioning) lets resolved-then-refiring alerts re-notify, which
   is the intended UX. The current code replaces on purpose.
-- **Don't add CI workflows** without confirming intent — the previous
-  `.github/workflows/build.yaml` was removed deliberately in the
-  reimplementation branch.
+- **Don't add build/test CI workflows** without confirming intent — the
+  previous `.github/workflows/build.yaml` was removed deliberately in the
+  reimplementation branch. The existing `continuous-delivery.yaml` and
+  `release.yaml` workflows cover packaging and releases only.
 
 ## When in doubt
 

--- a/Alertmanager/AlertmanagerApp.swift
+++ b/Alertmanager/AlertmanagerApp.swift
@@ -30,10 +30,12 @@ struct AlertmanagerApp: App {
     /// each test launch isolated from prior runs (and from the user's real
     /// data) while still exercising the on-disk persistence path.
     ///
-    /// UI tests can additionally pass `-uiTestSeedAlertmanagerURL <url>` to
-    /// pre-populate the store with a single `Alertmanager` row pointed at the
-    /// given URL (typically a loopback `FakeAlertmanagerServer`). This skips
-    /// the form-typing flow when a test only cares about display behavior.
+    /// UI tests can additionally set the `UI_TEST_SEED_ALERTMANAGER_URL`
+    /// environment variable to pre-populate the store with a single
+    /// `Alertmanager` row pointed at the given URL (typically a loopback
+    /// `FakeAlertmanagerServer`). The seeding itself happens in
+    /// `ContentView.seedFromLaunchArgumentsIfNeeded`. This skips the
+    /// form-typing flow when a test only cares about display behavior.
     var sharedModelContainer: ModelContainer = {
         let schema = Schema([
             Alertmanager.self,
@@ -111,7 +113,7 @@ struct AlertmanagerApp: App {
 
         // Menu bar popup. `isInserted` lets the user hide the icon entirely
         // from Settings without quitting the app. The `.window` style gives
-        // a 500x400 panel rather than a classic menu list.
+        // a 500x600 panel rather than a classic menu list.
         MenuBarExtra("Alertmanager", systemImage: "bell.fill", isInserted: $menuBarEnabled) {
             MenuBarContentView()
         }

--- a/Alertmanager/ContentView.swift
+++ b/Alertmanager/ContentView.swift
@@ -440,9 +440,9 @@ struct ContentView: View {
     /// No-op outside of that variable being present.
     ///
     /// Mirrors `AlertmanagerFormView.saveAlertmanager`'s create path:
-    /// explicit `fetch` via the env `modelContext` for idempotency,
-    /// explicit `sortOrder`, autosave only — the same shape the form-
-    /// driven CRUD tests exercise successfully.
+    /// explicit `fetch` via the env `modelContext` for idempotency and an
+    /// explicit `sortOrder`. Persistence relies on autosave — the seeded
+    /// row only needs to be visible to this context's `@Query`.
     private func seedFromLaunchArgumentsIfNeeded() {
         guard let url = uiTestEnvironmentValue(for: "UI_TEST_SEED_ALERTMANAGER_URL") else {
             return

--- a/Alertmanager/MenuBarContentView.swift
+++ b/Alertmanager/MenuBarContentView.swift
@@ -45,63 +45,40 @@ struct MenuBarContentView: View {
     /// they originated from (needed for deep-link construction in
     /// `AlertRowView`).
     ///
-    /// The filter's `selectedAlertmanagerIDs` narrows the source set; an
-    /// empty list means "all alertmanagers" (the shared semantic from
-    /// `Filter.includesAlertmanager(withID:)`). Alerts that share a
-    /// `fingerprint` across multiple alertmanagers are deduplicated; the
-    /// alertmanager that appears earliest in sidebar order wins and
-    /// determines which entity is paired with the surviving alert (so
-    /// `AlertRowView` builds a deterministic deep link). Results are
-    /// sorted by most-recently-started first.
+    /// Aggregation (sidebar-order visitation, dedup by fingerprint, filter
+    /// predicates, newest-first sort) is delegated to
+    /// `AlertAggregator.alertsWithSources`, the same helper the filter
+    /// detail view uses — so the popup and the main window always agree.
     private var filteredAlerts: [(alert: GettableAlert, alertmanager: Alertmanager)] {
         guard let filter = selectedFilter else { return [] }
-
-        let relevantAlertmanagers = alertmanagers.filter {
-            filter.includesAlertmanager(withID: $0.id)
-        }
-
-        var result: [(GettableAlert, Alertmanager)] = []
-        var seenFingerprints: Set<String> = []
-        for alertmanager in relevantAlertmanagers {
-            let alerts = alertsManager.getAlerts(for: alertmanager)
-            let matched = filter.apply(to: alerts)
-            for alert in matched where seenFingerprints.insert(alert.fingerprint).inserted {
-                result.append((alert, alertmanager))
-            }
-        }
-
-        return result.sorted { $0.0.startsAt > $1.0.startsAt }
+        return AlertAggregator.alertsWithSources(
+            for: filter,
+            from: alertsManager.alertsByAlertmanager,
+            orderedAlertmanagers: alertmanagers
+        )
     }
 
     var body: some View {
         VStack(spacing: 0) {
             if menuBarFilterID == nil {
                 // Empty state: user hasn't configured a filter for the menu bar.
-                VStack(spacing: 16) {
-                    Image(systemName: "line.3.horizontal.decrease.circle")
-                        .font(.system(size: 48))
-                        .foregroundColor(.orange)
-                    Text("No Filter Selected")
-                        .font(.headline)
-                    Text("Select a filter in the settings to show alerts here")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                }
+                ContentPlaceholderView(
+                    systemImage: "line.3.horizontal.decrease.circle",
+                    iconColor: .orange,
+                    title: "No Filter Selected",
+                    message: "Select a filter in the settings to show alerts here"
+                )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .accessibilityIdentifier("menubar-no-filter-state")
             } else if filteredAlerts.isEmpty {
                 // Empty state: filter is configured but currently matches
                 // nothing.
-                VStack(spacing: 16) {
-                    Image(systemName: "checkmark.circle")
-                        .font(.system(size: 48))
-                        .foregroundColor(.green)
-                    Text("No Alerts")
-                        .font(.headline)
-                    Text("No alerts found for filter criteria")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                }
+                ContentPlaceholderView(
+                    systemImage: "checkmark.circle",
+                    iconColor: .green,
+                    title: "No Alerts",
+                    message: "No alerts found for filter criteria"
+                )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .accessibilityIdentifier("menubar-empty-state")
             } else {

--- a/Alertmanager/MenuBarContentView.swift
+++ b/Alertmanager/MenuBarContentView.swift
@@ -8,10 +8,11 @@ import SwiftUI
 
 /// Content of the `MenuBarExtra` popup window.
 ///
-/// Displays alerts from the user-selected "menu bar filter" (configured in
-/// Settings via `@AppStorage("menuBarFilterID")`). Reads the same SwiftData
-/// store and `AlertsManager` cache as the main window, so polling already
-/// performed by `ContentView` is reused without additional network traffic.
+/// Displays alerts from the user-selected "menu bar filter" (chosen in
+/// Settings, persisted under the `menuBarFilterID` UserDefaults key and read
+/// here via `@AppStorage`). Reads the same SwiftData store and
+/// `AlertsManager` cache as the main window, so polling already performed by
+/// `ContentView` is reused without additional network traffic.
 struct MenuBarContentView: View {
     @Environment(\.modelContext) private var modelContext
 

--- a/Alertmanager/Models/Alert.swift
+++ b/Alertmanager/Models/Alert.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// An alert as returned by the Alertmanager `GET /api/v2/alerts` endpoint
-/// (and by Grafana's `GET /api/alertmanager/{name}/api/v2/alerts` endpoint).
+/// (and by Grafana's `GET /api/alertmanager/{uid}/api/v2/alerts` endpoint).
 ///
 /// Conforms to `Identifiable` using `fingerprint` so SwiftUI lists can diff
 /// alerts across refresh cycles without relying on array indices.

--- a/Alertmanager/Services/AlertAggregator.swift
+++ b/Alertmanager/Services/AlertAggregator.swift
@@ -9,9 +9,10 @@ import Foundation
 /// per-alertmanager cache dictionary.
 ///
 /// The same "collect from multiple backends, deduplicate by fingerprint,
-/// apply filter" pattern is needed in `SidebarFilterRowView` and
-/// `NotificationService`. Centralising it here keeps behaviour consistent
-/// and makes it directly testable without touching any UI or system code.
+/// apply filter" pattern is needed in `SidebarFilterRowView`,
+/// `NotificationService`, `FilterDetailView`, and `MenuBarContentView`.
+/// Centralising it here keeps behaviour consistent and makes it directly
+/// testable without touching any UI or system code.
 enum AlertAggregator {
 
     /// Returns the set of alerts that match `filter`, gathered from the
@@ -56,5 +57,53 @@ enum AlertAggregator {
         }
 
         return filter.apply(to: allAlerts)
+    }
+
+    /// Returns the alerts that match `filter` paired with the alertmanager
+    /// they were collected from.
+    ///
+    /// Same contract as `alerts(for:from:orderedAlertmanagerIDs:)` — visit
+    /// in sidebar order, deduplicate by fingerprint *before* applying the
+    /// filter's predicates — but preserves which alertmanager won dedup for
+    /// each alert so callers can build backend-specific deep links
+    /// (`AlertRowView` needs the entity, not just the alert).
+    ///
+    /// Results are sorted newest-first because every consumer (filter
+    /// detail view, menu bar popup) renders them in that order.
+    ///
+    /// - Parameters:
+    ///   - filter: The filter whose `selectedAlertmanagerIDs` and predicates
+    ///     are used.
+    ///   - cache: A dictionary mapping alertmanager IDs to their cached alert
+    ///     list (e.g. `AlertsManager.shared.alertsByAlertmanager`).
+    ///   - orderedAlertmanagers: All known alertmanagers in their sidebar
+    ///     order. Determines dedup precedence when the same fingerprint
+    ///     appears in multiple alertmanagers.
+    /// - Returns: Matching alerts paired with their dedup-winning source,
+    ///   sorted by `startsAt` descending.
+    static func alertsWithSources(
+        for filter: Filter,
+        from cache: [UUID: [GettableAlert]],
+        orderedAlertmanagers: [Alertmanager]
+    ) -> [(alert: GettableAlert, alertmanager: Alertmanager)] {
+        var pairs: [(alert: GettableAlert, alertmanager: Alertmanager)] = []
+        var seenFingerprints: Set<String> = []
+
+        for alertmanager in orderedAlertmanagers
+        where filter.includesAlertmanager(withID: alertmanager.id) {
+            let cached = cache[alertmanager.id] ?? []
+            for alert in cached where seenFingerprints.insert(alert.fingerprint).inserted {
+                pairs.append((alert, alertmanager))
+            }
+        }
+
+        // Apply the filter once over the deduplicated alerts, then keep the
+        // pairing for the survivors. Fingerprints are unique after dedup,
+        // so the set intersection is exact.
+        let matching = Set(filter.apply(to: pairs.map(\.alert)).map(\.fingerprint))
+        return
+            pairs
+            .filter { matching.contains($0.alert.fingerprint) }
+            .sorted { $0.alert.startsAt > $1.alert.startsAt }
     }
 }

--- a/Alertmanager/Services/AlertmanagerService.swift
+++ b/Alertmanager/Services/AlertmanagerService.swift
@@ -107,6 +107,47 @@ class AlertmanagerService {
         }
     }
 
+    // MARK: - Public Methods (Silence URL)
+
+    /// Resolves the "create silence" URL for `alert` against `alertmanager`.
+    ///
+    /// Shared by `AlertRowView` (Silence button) and `NotificationService`
+    /// (notification action) so both build identical URLs. For Grafana
+    /// backends the datasource *name* is resolved from the configured UID
+    /// first (see `fetchDatasourceName(for:in:)`) because Grafana's silence
+    /// form expects the name; the built-in `"grafana"` value is used
+    /// verbatim without a lookup.
+    ///
+    /// - Parameters:
+    ///   - alert: The alert whose labels populate the silence matchers.
+    ///   - alertmanager: The backend the alert was fetched from.
+    /// - Returns: The silence URL, or `nil` for a Grafana backend without a
+    ///   configured datasource — the resulting URL would target nothing
+    ///   actionable.
+    func resolveSilenceURL(
+        for alert: GettableAlert, in alertmanager: Alertmanager
+    ) async -> String? {
+        let configuredUID =
+            alertmanager.grafanaAlertmanager.isEmpty ? nil : alertmanager.grafanaAlertmanager
+
+        if alertmanager.isGrafana, configuredUID == nil {
+            return nil
+        }
+
+        let resolvedName: String?
+        if alertmanager.isGrafana, let uid = configuredUID, uid != "grafana" {
+            resolvedName = await fetchDatasourceName(for: uid, in: alertmanager)
+        } else {
+            resolvedName = nil
+        }
+
+        return AlertDeepLinks.silenceURL(
+            for: alert,
+            alertmanager: alertmanager,
+            resolvedDatasourceName: resolvedName
+        )
+    }
+
     // MARK: - Public Methods (Auth credentials)
 
     /// Resolves the configured authentication into a human-readable

--- a/Alertmanager/Services/AlertmanagerService.swift
+++ b/Alertmanager/Services/AlertmanagerService.swift
@@ -12,8 +12,11 @@ enum AlertmanagerError: LocalizedError {
     case invalidURL
     /// The server responded with HTTP 401 or 403.
     case authenticationFailed
-    /// Underlying transport failure (DNS, TLS, timeout, etc.) or a
-    /// non-2xx, non-auth status code.
+    /// The server responded with a non-2xx status code other than the
+    /// auth failures above. Carries the status code so the UI can show
+    /// what the backend actually returned.
+    case serverError(statusCode: Int)
+    /// Underlying transport failure (DNS, TLS, timeout, etc.).
     case networkError(Error)
     /// The response body could not be decoded into the expected type.
     case decodingError(Error)
@@ -27,6 +30,8 @@ enum AlertmanagerError: LocalizedError {
             return "Invalid Alertmanager URL"
         case .authenticationFailed:
             return "Authentication failed"
+        case .serverError(let statusCode):
+            return "Server returned HTTP \(statusCode)"
         case .networkError(let error):
             return "Network error: \(error.localizedDescription)"
         case .decodingError(let error):
@@ -225,7 +230,7 @@ class AlertmanagerService {
     /// Maps HTTP status codes to `AlertmanagerError`:
     /// - 200–299 → success, decoded as `T` using ISO-8601 dates.
     /// - 401 / 403 → `.authenticationFailed`
-    /// - other non-2xx → `.networkError(URLError(.badServerResponse))`
+    /// - other non-2xx → `.serverError(statusCode:)`
     ///
     /// Transport failures bubble up as `.networkError`; decode failures
     /// bubble up as `.decodingError`. `AlertmanagerError`s thrown from
@@ -242,7 +247,7 @@ class AlertmanagerService {
                 if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
                     throw AlertmanagerError.authenticationFailed
                 }
-                throw AlertmanagerError.networkError(URLError(.badServerResponse))
+                throw AlertmanagerError.serverError(statusCode: httpResponse.statusCode)
             }
 
             let decoder = JSONDecoder()

--- a/Alertmanager/Services/AlertsManager.swift
+++ b/Alertmanager/Services/AlertsManager.swift
@@ -13,10 +13,6 @@ extension Notification.Name {
     /// affected alertmanager so observers can scope their reactions.
     static let alertsDidUpdate = Notification.Name("alertsDidUpdate")
 
-    /// Posted when a filter's predicates change in a way that downstream
-    /// views need to re-evaluate. (Currently unused; kept for parity.)
-    static let filterDidUpdate = Notification.Name("filterDidUpdate")
-
     /// Posted by the "Export Configuration" menu command in
     /// `AlertmanagerApp`; observed by `ContentView`.
     static let exportConfiguration = Notification.Name("exportConfiguration")

--- a/Alertmanager/Services/NotificationService.swift
+++ b/Alertmanager/Services/NotificationService.swift
@@ -359,37 +359,25 @@ class NotificationService: NSObject {
 
             // Source — present only when the alert carries a generatorURL.
             if let generatorURL = alert.generatorURL,
-                let sanitized = sanitizeURL(generatorURL)
+                let sanitized = AlertDeepLinks.sanitize(generatorURL)
             {
                 userInfo[NotificationUserInfoKey.sourceURL] = sanitized
             }
 
-            // Silence — always constructible when the alertmanager is known.
-            // For Grafana backends, resolve the datasource name from its UID
-            // first (unless the UID is already the built-in "grafana" value).
-            if let alertmanager {
-                let configuredUID =
-                    alertmanager.grafanaAlertmanager.isEmpty
-                    ? nil : alertmanager.grafanaAlertmanager
-                let resolvedName: String?
-                if alertmanager.isGrafana, let uid = configuredUID, uid != "grafana" {
-                    resolvedName = await service.fetchDatasourceName(for: uid, in: alertmanager)
-                } else {
-                    resolvedName = nil
-                }
-
-                if let silenceURL = buildSilenceURL(
-                    for: alert,
-                    alertmanager: alertmanager,
-                    resolvedDatasourceName: resolvedName
-                ) {
-                    userInfo[NotificationUserInfoKey.silenceURL] = silenceURL
-                }
+            // Silence — constructible when the alertmanager is known (and,
+            // for Grafana backends, a datasource is configured). URL
+            // construction, including the Grafana datasource-name lookup,
+            // is shared with AlertRowView's Silence button via
+            // `AlertmanagerService.resolveSilenceURL`.
+            if let alertmanager,
+                let silenceURL = await service.resolveSilenceURL(for: alert, in: alertmanager)
+            {
+                userInfo[NotificationUserInfoKey.silenceURL] = silenceURL
             }
 
             // Runbook — present only when the annotation exists.
             if let runbookURL = alert.runbookURL,
-                let sanitized = sanitizeURL(runbookURL)
+                let sanitized = AlertDeepLinks.sanitize(runbookURL)
             {
                 userInfo[NotificationUserInfoKey.runbookURL] = sanitized
             }
@@ -398,12 +386,12 @@ class NotificationService: NSObject {
             if let alertmanager, alertmanager.isGrafana,
                 let dashboardUID = alert.annotations["__dashboardUid__"]
             {
-                let dashboardURL = "\(alertmanager.url)/d/\(dashboardUID)"
-                userInfo[NotificationUserInfoKey.dashboardURL] = dashboardURL
+                userInfo[NotificationUserInfoKey.dashboardURL] = AlertDeepLinks.dashboardURL(
+                    alertmanager: alertmanager, dashboardUID: dashboardUID)
 
                 if let panelId = alert.annotations["__panelId__"] {
-                    let panelURL = "\(alertmanager.url)/d/\(dashboardUID)?viewPanel=\(panelId)"
-                    userInfo[NotificationUserInfoKey.panelURL] = panelURL
+                    userInfo[NotificationUserInfoKey.panelURL] = AlertDeepLinks.panelURL(
+                        alertmanager: alertmanager, dashboardUID: dashboardUID, panelId: panelId)
                 }
             }
 
@@ -429,7 +417,7 @@ class NotificationService: NSObject {
         print("Sent \(alerts.count) notification(s) for filter '\(filter.name)'")
     }
 
-    // MARK: - URL helpers
+    // MARK: - Alertmanager resolution
 
     /// Finds the alertmanager that produced `alert`.
     ///
@@ -446,25 +434,6 @@ class NotificationService: NSObject {
             }
         }
         return nil
-    }
-
-    /// Builds the silence URL for `alert` against `alertmanager`.
-    /// Delegates to `AlertDeepLinks.silenceURL(for:alertmanager:resolvedDatasourceName:)`.
-    private func buildSilenceURL(
-        for alert: GettableAlert,
-        alertmanager: Alertmanager,
-        resolvedDatasourceName: String? = nil
-    ) -> String? {
-        AlertDeepLinks.silenceURL(
-            for: alert,
-            alertmanager: alertmanager,
-            resolvedDatasourceName: resolvedDatasourceName
-        )
-    }
-
-    /// Sanitizes a URL string via `AlertDeepLinks.sanitize(_:)`.
-    private func sanitizeURL(_ urlString: String) -> String? {
-        AlertDeepLinks.sanitize(urlString)
     }
 }
 

--- a/Alertmanager/Services/NotificationService.swift
+++ b/Alertmanager/Services/NotificationService.swift
@@ -11,7 +11,11 @@ import UserNotifications
 
 /// `userInfo` keys used to ferry deep-link URLs through the notification
 /// payload to the action handler in `NotificationService`.
-enum NotificationUserInfoKey {
+///
+/// `nonisolated` so the constants are also usable from the nonisolated
+/// `UNUserNotificationCenterDelegate` methods (the project-wide `MainActor`
+/// default would otherwise isolate them).
+nonisolated enum NotificationUserInfoKey {
     static let sourceURL = "sourceURL"
     static let silenceURL = "silenceURL"
     static let runbookURL = "runbookURL"
@@ -24,7 +28,9 @@ enum NotificationUserInfoKey {
 }
 
 /// `UNNotificationAction` identifiers used by `NotificationService`.
-enum NotificationActionIdentifier {
+///
+/// `nonisolated` for the same reason as `NotificationUserInfoKey`.
+nonisolated enum NotificationActionIdentifier {
     static let openSource = "OPEN_SOURCE"
     static let openSilence = "OPEN_SILENCE"
     static let openRunbook = "OPEN_RUNBOOK"
@@ -167,26 +173,32 @@ class NotificationService: NSObject {
             (
                 0,
                 UNNotificationAction(
-                    identifier: "OPEN_SOURCE", title: "Source", options: .foreground)
+                    identifier: NotificationActionIdentifier.openSource, title: "Source",
+                    options: .foreground)
             ),
             (
                 1,
                 UNNotificationAction(
-                    identifier: "OPEN_SILENCE", title: "Silence", options: .foreground)
+                    identifier: NotificationActionIdentifier.openSilence, title: "Silence",
+                    options: .foreground)
             ),
             (
                 2,
                 UNNotificationAction(
-                    identifier: "OPEN_RUNBOOK", title: "Runbook", options: .foreground)
+                    identifier: NotificationActionIdentifier.openRunbook, title: "Runbook",
+                    options: .foreground)
             ),
             (
                 3,
                 UNNotificationAction(
-                    identifier: "OPEN_DASHBOARD", title: "Dashboard", options: .foreground)
+                    identifier: NotificationActionIdentifier.openDashboard, title: "Dashboard",
+                    options: .foreground)
             ),
             (
                 4,
-                UNNotificationAction(identifier: "OPEN_PANEL", title: "Panel", options: .foreground)
+                UNNotificationAction(
+                    identifier: NotificationActionIdentifier.openPanel, title: "Panel",
+                    options: .foreground)
             ),
         ]
 
@@ -453,16 +465,13 @@ extension NotificationService: UNUserNotificationCenterDelegate {
 
         let userInfo = response.notification.request.content.userInfo
 
-        // Use raw string literals here — the enums are MainActor-isolated
-        // (project-wide default) and cannot be referenced from this
-        // nonisolated delegate method.
-
         // Default tap (user tapped the notification body, not an action
         // button): open the alert-detail window.
         if response.actionIdentifier == UNNotificationDefaultActionIdentifier {
             guard
-                let fingerprint = userInfo["fingerprint"] as? String,
-                let alertmanagerIDString = userInfo["alertmanagerID"] as? String,
+                let fingerprint = userInfo[NotificationUserInfoKey.fingerprint] as? String,
+                let alertmanagerIDString = userInfo[NotificationUserInfoKey.alertmanagerID]
+                    as? String,
                 let alertmanagerID = UUID(uuidString: alertmanagerIDString)
             else { return }
 
@@ -499,16 +508,16 @@ extension NotificationService: UNUserNotificationCenterDelegate {
 
         let urlKey: String
         switch response.actionIdentifier {
-        case "OPEN_SOURCE":
-            urlKey = "sourceURL"
-        case "OPEN_SILENCE":
-            urlKey = "silenceURL"
-        case "OPEN_RUNBOOK":
-            urlKey = "runbookURL"
-        case "OPEN_DASHBOARD":
-            urlKey = "dashboardURL"
-        case "OPEN_PANEL":
-            urlKey = "panelURL"
+        case NotificationActionIdentifier.openSource:
+            urlKey = NotificationUserInfoKey.sourceURL
+        case NotificationActionIdentifier.openSilence:
+            urlKey = NotificationUserInfoKey.silenceURL
+        case NotificationActionIdentifier.openRunbook:
+            urlKey = NotificationUserInfoKey.runbookURL
+        case NotificationActionIdentifier.openDashboard:
+            urlKey = NotificationUserInfoKey.dashboardURL
+        case NotificationActionIdentifier.openPanel:
+            urlKey = NotificationUserInfoKey.panelURL
         default:
             return
         }

--- a/Alertmanager/Views/AlertRowView.swift
+++ b/Alertmanager/Views/AlertRowView.swift
@@ -432,36 +432,18 @@ struct AlertRowView: View {
 
     /// Builds and opens the "create silence" URL for this alert.
     ///
-    /// Two backend variants are supported:
-    /// - **Grafana**: targets `{url}/alerting/silence/new` with one
-    ///   `matcher=key%3Dvalue` query item per label, and an
-    ///   `alertmanager=` parameter set to the datasource *name*. When the
-    ///   resolved UID is not `"grafana"`, the name is resolved via
-    ///   `GET {url}/api/datasources/uid/{uid}` because Grafana expects the
-    ///   human-readable name rather than the datasource UID.
-    /// - **Standard Alertmanager**: targets `{url}/#/silences/new` with a
-    ///   single `filter={k1="v1", k2="v2"}` query value, percent-encoded.
+    /// URL construction — including resolving the Grafana datasource name
+    /// from its UID — is shared with the notification actions via
+    /// `AlertmanagerService.resolveSilenceURL(for:in:)`. The URL is `nil`
+    /// for a Grafana backend without a configured datasource.
     private func openSilenceURL() async {
-        let configuredUID =
-            alertmanager.grafanaAlertmanager.isEmpty ? nil : alertmanager.grafanaAlertmanager
-        let resolvedName: String?
-        if alertmanager.isGrafana, let uid = configuredUID, uid != "grafana" {
-            let service = AlertmanagerService()
-            resolvedName = await service.fetchDatasourceName(for: uid, in: alertmanager)
-        } else {
-            resolvedName = nil
-        }
-
-        if alertmanager.isGrafana, configuredUID == nil {
+        let service = AlertmanagerService()
+        guard let urlString = await service.resolveSilenceURL(for: alert, in: alertmanager)
+        else {
             print("No Grafana alertmanager configured")
             return
         }
 
-        let urlString = AlertDeepLinks.silenceURL(
-            for: alert,
-            alertmanager: alertmanager,
-            resolvedDatasourceName: resolvedName
-        )
         print("Opening silence URL: \(urlString)")
         openURL(urlString)
     }

--- a/Alertmanager/Views/AlertRowView.swift
+++ b/Alertmanager/Views/AlertRowView.swift
@@ -35,7 +35,8 @@ struct AlertRowView: View {
     var isMenuBar: Bool = false
 
     /// When `true`, the row starts in its expanded state. Used by
-    /// `AlertDetailView` to render the alert fully expanded from the outset.
+    /// `ContentView`'s alert-detail pane (notification taps) to render the
+    /// alert fully expanded from the outset.
     var isExpanded: Bool = false
 
     /// Tracks whether the expanded detail section is shown.

--- a/Alertmanager/Views/AlertSearchField.swift
+++ b/Alertmanager/Views/AlertSearchField.swift
@@ -1,0 +1,28 @@
+//
+//  AlertSearchField.swift
+//  Alertmanager
+//
+
+import SwiftUI
+
+/// Toolbar search field shared by the alertmanager and filter detail views.
+///
+/// Holds the raw query text and, on submit, parses it into `LabelMatcher`
+/// values via `LabelMatcher.parse(query:)` so the owning view can apply the
+/// matchers on top of its own predicates.
+struct AlertSearchField: View {
+    /// Raw text typed into the field.
+    @Binding var query: String
+
+    /// Parsed label matchers derived from `query` on submit.
+    @Binding var matchers: [LabelMatcher]
+
+    var body: some View {
+        TextField("Search", text: $query)
+            .textFieldStyle(.roundedBorder)
+            .frame(minWidth: 200, maxWidth: 400)
+            .onSubmit {
+                matchers = LabelMatcher.parse(query: query)
+            }
+    }
+}

--- a/Alertmanager/Views/AlertmanagerDetailView.swift
+++ b/Alertmanager/Views/AlertmanagerDetailView.swift
@@ -81,16 +81,12 @@ struct AlertmanagerDetailView: View {
                 // Healthy empty state: backend reachable, no active alerts.
                 VStack {
                     Spacer()
-                    VStack(spacing: 16) {
-                        Image(systemName: "checkmark.circle")
-                            .font(.system(size: 48))
-                            .foregroundColor(.green)
-                        Text("No Alerts")
-                            .font(.headline)
-                        Text("No alerts found for this Alertmanager")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
-                    }
+                    ContentPlaceholderView(
+                        systemImage: "checkmark.circle",
+                        iconColor: .green,
+                        title: "No Alerts",
+                        message: "No alerts found for this Alertmanager"
+                    )
                     Spacer()
                 }
             } else {
@@ -109,12 +105,7 @@ struct AlertmanagerDetailView: View {
         .navigationTitle(alertmanager.name.isEmpty ? alertmanager.url : alertmanager.name)
         .toolbar {
             ToolbarItem(placement: .principal) {
-                TextField("Search", text: $searchQuery)
-                    .textFieldStyle(.roundedBorder)
-                    .frame(minWidth: 200, maxWidth: 400)
-                    .onSubmit {
-                        searchMatchers = LabelMatcher.parse(query: searchQuery)
-                    }
+                AlertSearchField(query: $searchQuery, matchers: $searchMatchers)
             }
 
             ToolbarItem(placement: .automatic) {

--- a/Alertmanager/Views/AlertmanagerFormView.swift
+++ b/Alertmanager/Views/AlertmanagerFormView.swift
@@ -249,8 +249,10 @@ struct AlertmanagerFormView: View {
     /// Reassembles the nested `AuthenticationType` from the flat UI
     /// selectors, then either mutates the existing entity (edit mode) or
     /// inserts a new one with the next `sortOrder` (create mode). In both
-    /// cases polling is restarted so the change takes effect immediately,
-    /// and the sheet is dismissed.
+    /// cases polling is restarted so the change takes effect immediately.
+    /// The model context is explicitly saved (matching `FilterFormView`)
+    /// so the change is visible to `@Query` consumers immediately; the
+    /// sheet is dismissed only on a successful save.
     private func saveAlertmanager() {
         let authType = Self.buildAuthType(
             selectedAuth: selectedAuthType,
@@ -291,7 +293,12 @@ struct AlertmanagerFormView: View {
             AlertsManager.shared.startMonitoring(alertmanager: newAlertmanager)
         }
 
-        dismiss()
+        do {
+            try modelContext.save()
+            dismiss()
+        } catch {
+            print("Failed to save alertmanager: \(error)")
+        }
     }
 }
 

--- a/Alertmanager/Views/ContentPlaceholderView.swift
+++ b/Alertmanager/Views/ContentPlaceholderView.swift
@@ -1,0 +1,39 @@
+//
+//  ContentPlaceholderView.swift
+//  Alertmanager
+//
+
+import SwiftUI
+
+/// Centered icon + title + message stack used for the app's various empty
+/// states (no alerts, no menu-bar filter selected).
+///
+/// The component renders only the inner stack; call sites are responsible
+/// for positioning (Spacer stacks or frames) and for attaching their own
+/// accessibility identifiers.
+struct ContentPlaceholderView: View {
+    /// SF Symbol name rendered above the title.
+    let systemImage: String
+
+    /// Tint applied to the symbol.
+    let iconColor: Color
+
+    /// Headline shown below the icon.
+    let title: String
+
+    /// Secondary explanatory text.
+    let message: String
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: systemImage)
+                .font(.system(size: 48))
+                .foregroundColor(iconColor)
+            Text(title)
+                .font(.headline)
+            Text(message)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+    }
+}

--- a/Alertmanager/Views/CountBadge.swift
+++ b/Alertmanager/Views/CountBadge.swift
@@ -1,0 +1,25 @@
+//
+//  CountBadge.swift
+//  Alertmanager
+//
+
+import SwiftUI
+
+/// Capsule badge showing an alert count — red when greater than zero
+/// (attention required), green when zero (all clear). Shared by the
+/// sidebar row views.
+struct CountBadge: View {
+    /// The number to display.
+    let count: Int
+
+    var body: some View {
+        Text("\(count)")
+            .font(.caption)
+            .fontWeight(.semibold)
+            .foregroundColor(.white)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(count > 0 ? Color.red : Color.green)
+            .clipShape(Capsule())
+    }
+}

--- a/Alertmanager/Views/FilterDetailView.swift
+++ b/Alertmanager/Views/FilterDetailView.swift
@@ -25,8 +25,10 @@ struct FilterDetailView: View {
     /// Presents the destructive delete confirmation alert.
     @State private var showingDeleteAlert = false
 
-    /// Filtered, deduplicated, sorted alerts displayed in the list.
-    @State private var alerts: [GettableAlert] = []
+    /// Filtered, deduplicated, sorted alerts displayed in the list, each
+    /// paired with the alertmanager that won dedup (needed by
+    /// `AlertRowView` for deep-link construction).
+    @State private var alerts: [(alert: GettableAlert, alertmanager: Alertmanager)] = []
 
     /// `true` while at least one source alertmanager is performing an
     /// initial fetch.
@@ -64,28 +66,21 @@ struct FilterDetailView: View {
                 // Healthy empty state: nothing currently matches the filter.
                 VStack {
                     Spacer()
-                    VStack(spacing: 16) {
-                        Image(systemName: "checkmark.circle")
-                            .font(.system(size: 48))
-                            .foregroundColor(.green)
-                        Text("No Alerts")
-                            .font(.headline)
-                        Text("No alerts found for filter criteria")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
-                    }
+                    ContentPlaceholderView(
+                        systemImage: "checkmark.circle",
+                        iconColor: .green,
+                        title: "No Alerts",
+                        message: "No alerts found for filter criteria"
+                    )
                     Spacer()
                 }
             } else {
-                // Populated state. Each row needs its originating
-                // alertmanager for deep-link construction; rows whose
-                // source can no longer be resolved are skipped.
+                // Populated state. Each row carries its dedup-winning
+                // alertmanager for deep-link construction.
                 ScrollView {
                     LazyVStack(spacing: 12) {
-                        ForEach(filteredAlerts) { alert in
-                            if let alertmanager = findAlertmanager(for: alert) {
-                                AlertRowView(alert: alert, alertmanager: alertmanager)
-                            }
+                        ForEach(filteredAlerts, id: \.alert.id) { item in
+                            AlertRowView(alert: item.alert, alertmanager: item.alertmanager)
                         }
                     }
                     .padding()
@@ -95,12 +90,7 @@ struct FilterDetailView: View {
         .navigationTitle(filter.name)
         .toolbar {
             ToolbarItem(placement: .principal) {
-                TextField("Search", text: $searchQuery)
-                    .textFieldStyle(.roundedBorder)
-                    .frame(minWidth: 200, maxWidth: 400)
-                    .onSubmit {
-                        searchMatchers = LabelMatcher.parse(query: searchQuery)
-                    }
+                AlertSearchField(query: $searchQuery, matchers: $searchMatchers)
             }
 
             ToolbarItem(placement: .automatic) {
@@ -176,52 +166,33 @@ struct FilterDetailView: View {
     ///
     /// When `searchMatchers` is empty (no or unparseable query) the
     /// filter-matched `alerts` list is returned unchanged.
-    private var filteredAlerts: [GettableAlert] {
+    private var filteredAlerts: [(alert: GettableAlert, alertmanager: Alertmanager)] {
         guard !searchMatchers.isEmpty else { return alerts }
-        return alerts.filter { alert in
-            searchMatchers.allSatisfy { $0.evaluate(against: alert.labels) }
+        return alerts.filter { item in
+            searchMatchers.allSatisfy { $0.evaluate(against: item.alert.labels) }
         }
     }
 
     /// Recomputes `alerts` and `isLoading` from `AlertsManager`'s caches.
     ///
-    /// Walks every alertmanager referenced by the filter **in sidebar order**,
-    /// collects each backend's alerts, deduplicates by `fingerprint` (the same
-    /// alert can be produced by multiple alertmanagers), applies the filter's
-    /// predicates, and sorts newest-first. Iterating in sidebar order rather
-    /// than `filter.selectedAlertmanagerIDs` order — which reflects the
-    /// (effectively random) order checkboxes were ticked in the form — makes
-    /// dedup precedence match what the user sees in the sidebar, and matches
-    /// `AlertAggregator`'s contract.
+    /// Aggregation (sidebar-order visitation, dedup by fingerprint, filter
+    /// predicates, alert-to-alertmanager pairing, newest-first sort) is
+    /// delegated to `AlertAggregator.alertsWithSources`, the same helper
+    /// the menu bar popup uses — so both surfaces always agree.
     ///
     /// Notification checking is handled centrally by `NotificationService`,
     /// which subscribes to `.alertsDidUpdate` and checks all filters
     /// independently of which view is visible.
     private func updateAlerts() {
-        var allAlerts: [GettableAlert] = []
-        var seenFingerprints: Set<String> = []
-        var anyLoading = false
-
-        for alertmanager in alertmanagers
-        where filter.includesAlertmanager(withID: alertmanager.id) {
-            let alerts = AlertsManager.shared.alertsByAlertmanager[alertmanager.id] ?? []
-
-            for alert in alerts {
-                if !seenFingerprints.contains(alert.fingerprint) {
-                    seenFingerprints.insert(alert.fingerprint)
-                    allAlerts.append(alert)
-                }
-            }
-
-            if AlertsManager.shared.isLoadingByAlertmanager[alertmanager.id] ?? false {
-                anyLoading = true
-            }
+        alerts = AlertAggregator.alertsWithSources(
+            for: filter,
+            from: AlertsManager.shared.alertsByAlertmanager,
+            orderedAlertmanagers: alertmanagers
+        )
+        isLoading = alertmanagers.contains {
+            filter.includesAlertmanager(withID: $0.id)
+                && (AlertsManager.shared.isLoadingByAlertmanager[$0.id] ?? false)
         }
-
-        let filteredAlerts = filter.apply(to: allAlerts).sorted { $0.startsAt > $1.startsAt }
-
-        alerts = filteredAlerts
-        isLoading = anyLoading
     }
 
     /// Forces an out-of-band refresh on every alertmanager referenced by
@@ -232,27 +203,6 @@ struct FilterDetailView: View {
         where filter.includesAlertmanager(withID: alertmanager.id) {
             AlertsManager.shared.refresh(alertmanager: alertmanager)
         }
-    }
-
-    /// Resolves which alertmanager produced `alert` so `AlertRowView` can
-    /// construct correct silence/dashboard URLs.
-    ///
-    /// Searches each source alertmanager's cache for a matching alert id **in
-    /// sidebar order**, so when the same fingerprint is present in multiple
-    /// alertmanagers the row consistently pairs with the one that wins dedup
-    /// in `updateAlerts()`. Falls back to the first known alertmanager if
-    /// nothing matches (which can happen briefly when caches are still being
-    /// populated).
-    private func findAlertmanager(for alert: GettableAlert) -> Alertmanager? {
-        for alertmanager in alertmanagers
-        where filter.includesAlertmanager(withID: alertmanager.id) {
-            let alertmanagerAlerts =
-                AlertsManager.shared.alertsByAlertmanager[alertmanager.id] ?? []
-            if alertmanagerAlerts.contains(where: { $0.id == alert.id }) {
-                return alertmanager
-            }
-        }
-        return alertmanagers.first
     }
 
     /// Removes the filter from the model context. Polling is unaffected

--- a/Alertmanager/Views/FilterFormView.swift
+++ b/Alertmanager/Views/FilterFormView.swift
@@ -33,7 +33,8 @@ struct FilterFormView: View {
     @State private var name: String = ""
     /// IDs of source alertmanagers to query.
     @State private var selectedAlertmanagers: Set<UUID> = []
-    /// Alert states to include (empty = none).
+    /// Alert states to include (empty disables the state predicate, i.e.
+    /// alerts in any state match).
     @State private var selectedStates: Set<AlertState> = []
     /// Receiver-name allowlist.
     @State private var selectedReceivers: Set<String> = []

--- a/Alertmanager/Views/SidebarAlertmanagerRowView.swift
+++ b/Alertmanager/Views/SidebarAlertmanagerRowView.swift
@@ -59,14 +59,7 @@ struct SidebarAlertmanagerRowView: View {
             } else {
                 // Capsule badge with the current alert count. Red signals
                 // there are active alerts, green signals all-clear.
-                Text("\(alertCount)")
-                    .font(.caption)
-                    .fontWeight(.semibold)
-                    .foregroundColor(.white)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(alertCount > 0 ? Color.red : Color.green)
-                    .clipShape(Capsule())
+                CountBadge(count: alertCount)
             }
         }
         .onAppear {

--- a/Alertmanager/Views/SidebarFilterRowView.swift
+++ b/Alertmanager/Views/SidebarFilterRowView.swift
@@ -43,14 +43,7 @@ struct SidebarFilterRowView: View {
             } else {
                 // Capsule badge with the matching-alert count. Red signals
                 // there are matches, green signals no matches.
-                Text("\(alertCount)")
-                    .font(.caption)
-                    .fontWeight(.semibold)
-                    .foregroundColor(.white)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(alertCount > 0 ? Color.red : Color.green)
-                    .clipShape(Capsule())
+                CountBadge(count: alertCount)
             }
         }
         .onAppear {

--- a/Alertmanager/Views/SidebarFilterRowView.swift
+++ b/Alertmanager/Views/SidebarFilterRowView.swift
@@ -24,11 +24,6 @@ struct SidebarFilterRowView: View {
     /// Cached count of matching alerts shown in the badge.
     @State private var alertCount: Int = 0
 
-    /// `true` while a fetch is in flight; drives the spinner.
-    /// (Currently never set — left in place for parity with the
-    /// alertmanager row's badge UI.)
-    @State private var isLoading: Bool = false
-
     var body: some View {
         HStack {
             Text(filter.name)
@@ -37,14 +32,9 @@ struct SidebarFilterRowView: View {
 
             Spacer()
 
-            if isLoading {
-                ProgressView()
-                    .scaleEffect(0.6)
-            } else {
-                // Capsule badge with the matching-alert count. Red signals
-                // there are matches, green signals no matches.
-                CountBadge(count: alertCount)
-            }
+            // Capsule badge with the matching-alert count. Red signals
+            // there are matches, green signals no matches.
+            CountBadge(count: alertCount)
         }
         .onAppear {
             updateAlertCount()

--- a/AlertmanagerTests/AlertAggregatorTests.swift
+++ b/AlertmanagerTests/AlertAggregatorTests.swift
@@ -13,19 +13,24 @@ import Testing
 private func makeAlert(
     fingerprint: String,
     state: AlertState = .active,
-    labels: [String: String] = [:]
+    labels: [String: String] = [:],
+    startsAt: Date = Date()
 ) -> GettableAlert {
     GettableAlert(
         annotations: [:],
         receivers: [],
         fingerprint: fingerprint,
-        startsAt: Date(),
+        startsAt: startsAt,
         updatedAt: Date(),
         endsAt: Date(),
         status: AlertStatus(state: state, silencedBy: [], inhibitedBy: []),
         labels: labels,
         generatorURL: nil
     )
+}
+
+private func makeAlertmanager(name: String) -> Alertmanager {
+    Alertmanager(name: name, url: "https://\(name).example.com")
 }
 
 // MARK: - AlertAggregator tests
@@ -205,6 +210,99 @@ struct AlertAggregatorTests {
             orderedAlertmanagerIDs: [id]
         )
         #expect(result.isEmpty)
+    }
+}
+
+// MARK: - AlertAggregator.alertsWithSources tests
+
+@Suite("AlertAggregator.alertsWithSources")
+struct AlertAggregatorAlertsWithSourcesTests {
+
+    @Test("Pairs each alert with the alertmanager that won dedup")
+    func pairsWithDedupWinner() {
+        let am1 = makeAlertmanager(name: "am1")
+        let am2 = makeAlertmanager(name: "am2")
+        let filter = Filter(name: "f", selectedAlertmanagerIDs: [am1.id, am2.id], states: [])
+        let cache: [UUID: [GettableAlert]] = [
+            am1.id: [makeAlert(fingerprint: "shared")],
+            am2.id: [makeAlert(fingerprint: "shared"), makeAlert(fingerprint: "only2")],
+        ]
+
+        let result = AlertAggregator.alertsWithSources(
+            for: filter,
+            from: cache,
+            orderedAlertmanagers: [am1, am2]
+        )
+        #expect(result.count == 2)
+        // am1 is first in sidebar order, so its copy of "shared" wins.
+        #expect(result.first(where: { $0.alert.fingerprint == "shared" })?.alertmanager.id == am1.id)
+        #expect(result.first(where: { $0.alert.fingerprint == "only2" })?.alertmanager.id == am2.id)
+    }
+
+    @Test("Applies the filter after deduplication, matching alerts(for:)")
+    func filterAppliedAfterDedup() {
+        // The same fingerprint is suppressed in the dedup winner (am1) but
+        // active in am2. Dedup-before-filter keeps the am1 copy and the
+        // state predicate then drops it — identical to what
+        // alerts(for:from:orderedAlertmanagerIDs:) produces.
+        let am1 = makeAlertmanager(name: "am1")
+        let am2 = makeAlertmanager(name: "am2")
+        let filter = Filter(name: "f", selectedAlertmanagerIDs: [am1.id, am2.id], states: [.active])
+        let cache: [UUID: [GettableAlert]] = [
+            am1.id: [makeAlert(fingerprint: "shared", state: .suppressed)],
+            am2.id: [makeAlert(fingerprint: "shared", state: .active)],
+        ]
+
+        let result = AlertAggregator.alertsWithSources(
+            for: filter,
+            from: cache,
+            orderedAlertmanagers: [am1, am2]
+        )
+        #expect(result.isEmpty)
+
+        let plain = AlertAggregator.alerts(
+            for: filter,
+            from: cache,
+            orderedAlertmanagerIDs: [am1.id, am2.id]
+        )
+        #expect(plain.isEmpty)
+    }
+
+    @Test("Sorts results newest-first")
+    func sortsNewestFirst() {
+        let am = makeAlertmanager(name: "am1")
+        let filter = Filter(name: "f", selectedAlertmanagerIDs: [am.id], states: [])
+        let cache: [UUID: [GettableAlert]] = [
+            am.id: [
+                makeAlert(fingerprint: "old", startsAt: Date(timeIntervalSince1970: 1_000)),
+                makeAlert(fingerprint: "new", startsAt: Date(timeIntervalSince1970: 2_000)),
+            ]
+        ]
+
+        let result = AlertAggregator.alertsWithSources(
+            for: filter,
+            from: cache,
+            orderedAlertmanagers: [am]
+        )
+        #expect(result.map(\.alert.fingerprint) == ["new", "old"])
+    }
+
+    @Test("Empty selection means all alertmanagers")
+    func emptySelectionMeansAllAlertmanagers() {
+        let am1 = makeAlertmanager(name: "am1")
+        let am2 = makeAlertmanager(name: "am2")
+        let filter = Filter(name: "f", selectedAlertmanagerIDs: [], states: [])
+        let cache: [UUID: [GettableAlert]] = [
+            am1.id: [makeAlert(fingerprint: "a1")],
+            am2.id: [makeAlert(fingerprint: "b1")],
+        ]
+
+        let result = AlertAggregator.alertsWithSources(
+            for: filter,
+            from: cache,
+            orderedAlertmanagers: [am1, am2]
+        )
+        #expect(Set(result.map(\.alert.fingerprint)) == ["a1", "b1"])
     }
 }
 

--- a/AlertmanagerTests/ImportExportManagerTests.swift
+++ b/AlertmanagerTests/ImportExportManagerTests.swift
@@ -26,6 +26,43 @@ private func makeAlertmanager(
     Alertmanager(name: name, url: url, authType: authType)
 }
 
+/// Snapshot of every `SettingsManager` preference.
+///
+/// `ImportExportManager.importData` writes imported settings straight into
+/// `SettingsManager.shared` — i.e. the real `UserDefaults` of the test host
+/// — and `exportData` embeds the current settings into every export. Tests
+/// that exercise import must therefore capture the settings up front and
+/// restore them on exit, or they clobber the developer's actual
+/// configuration (refresh interval, menu-bar filter selection, …).
+///
+/// Usage: `let snapshot = SettingsSnapshot(); defer { snapshot.restore() }`.
+@MainActor
+private struct SettingsSnapshot {
+    private let refreshInterval: TimeInterval
+    private let menuBarEnabled: Bool
+    private let menuBarFilterID: String?
+    private let labelBadgeConfigs: [LabelBadgeConfig]
+    private let showAlertmanagerName: Bool
+
+    init() {
+        let settings = SettingsManager.shared
+        refreshInterval = settings.refreshInterval
+        menuBarEnabled = settings.menuBarEnabled
+        menuBarFilterID = settings.menuBarFilterID
+        labelBadgeConfigs = settings.labelBadgeConfigs
+        showAlertmanagerName = settings.showAlertmanagerName
+    }
+
+    func restore() {
+        let settings = SettingsManager.shared
+        settings.refreshInterval = refreshInterval
+        settings.menuBarEnabled = menuBarEnabled
+        settings.menuBarFilterID = menuBarFilterID
+        settings.labelBadgeConfigs = labelBadgeConfigs
+        settings.showAlertmanagerName = showAlertmanagerName
+    }
+}
+
 // MARK: - ExportAuthType decode
 
 @Suite("ExportAuthType decode")
@@ -82,6 +119,9 @@ struct ImportExportRoundTripTests {
     @Test("Round-trip: export then import produces same alertmanager count")
     @MainActor
     func roundTripAlertmanagerCount() throws {
+        let snapshot = SettingsSnapshot()
+        defer { snapshot.restore() }
+
         let container = try makeInMemoryContainer()
         let context = ModelContext(container)
 
@@ -112,6 +152,9 @@ struct ImportExportRoundTripTests {
     @Test("Round-trip: filter references alertmanager by name")
     @MainActor
     func filterReferenceByName() throws {
+        let snapshot = SettingsSnapshot()
+        defer { snapshot.restore() }
+
         let container = try makeInMemoryContainer()
         let context = ModelContext(container)
 
@@ -153,6 +196,9 @@ struct ImportExportRoundTripTests {
     @Test("Importing the same file twice does not duplicate alertmanagers")
     @MainActor
     func noDuplicatesOnSecondImport() throws {
+        let snapshot = SettingsSnapshot()
+        defer { snapshot.restore() }
+
         let container = try makeInMemoryContainer()
         let context = ModelContext(container)
 
@@ -192,6 +238,9 @@ struct ImportExportRoundTripTests {
     @Test("Importing the same file twice does not duplicate filters")
     @MainActor
     func noFilterDuplicatesOnSecondImport() throws {
+        let snapshot = SettingsSnapshot()
+        defer { snapshot.restore() }
+
         let container = try makeInMemoryContainer()
         let context = ModelContext(container)
 
@@ -383,6 +432,9 @@ struct ImportExportRoundTripTests {
     @Test("AuthType round-trip: basicAuth preserved through export→import")
     @MainActor
     func authTypeBasicAuthRoundTrip() throws {
+        let snapshot = SettingsSnapshot()
+        defer { snapshot.restore() }
+
         let container = try makeInMemoryContainer()
         let context = ModelContext(container)
 
@@ -413,6 +465,9 @@ struct ImportExportRoundTripTests {
     @Test("settingsRestored is true when settings block is present")
     @MainActor
     func settingsRestoredFlag() throws {
+        let snapshot = SettingsSnapshot()
+        defer { snapshot.restore() }
+
         let exportJSON = """
         {
             "alertmanagers": [],

--- a/AlertmanagerUITests/FakeAlertmanagerServer.swift
+++ b/AlertmanagerUITests/FakeAlertmanagerServer.swift
@@ -11,8 +11,8 @@ import Network
 ///
 /// Listens on `127.0.0.1` with an OS-assigned port. The resolved
 /// `http://127.0.0.1:<port>` URL is passed to the app under test via the
-/// `-uiTestSeedAlertmanagerURL` launch argument, so the seeded `Alertmanager`
-/// row in SwiftData points at this listener.
+/// `UI_TEST_SEED_ALERTMANAGER_URL` environment variable, so the seeded
+/// `Alertmanager` row in SwiftData points at this listener.
 ///
 /// The server is intentionally minimal: it reads up to one buffer of bytes
 /// from each connection, ignores the request line, and writes the configured
@@ -37,7 +37,7 @@ final class FakeAlertmanagerServer {
     private(set) var port: UInt16 = 0
 
     /// Loopback base URL pointing at this listener. Pass to the app via
-    /// `-uiTestSeedAlertmanagerURL`.
+    /// the `UI_TEST_SEED_ALERTMANAGER_URL` environment variable.
     var baseURL: String { "http://127.0.0.1:\(port)" }
 
     init(response: Response) throws {

--- a/AlertmanagerUITests/ImportExportRoundTripTests.swift
+++ b/AlertmanagerUITests/ImportExportRoundTripTests.swift
@@ -11,9 +11,9 @@ import XCTest
 /// serialized to a real JSON file on disk, the store is wiped via the
 /// Reset Configuration menu command, and the file is then re-imported.
 /// The NSSavePanel / NSOpenPanel UI is bypassed via the
-/// `-uiTestExportPath` / `-uiTestImportPath` launch arguments so the test
-/// doesn't have to drive a system file dialog, and the initial
-/// alertmanager is created via `-uiTestSeedAlertmanagerURL` to avoid
+/// `UI_TEST_EXPORT_PATH` / `UI_TEST_IMPORT_PATH` environment variables so
+/// the test doesn't have to drive a system file dialog, and the initial
+/// alertmanager is created via `UI_TEST_SEED_ALERTMANAGER_URL` to avoid
 /// driving the Add Alertmanager form (which was flaky on CI macOS runners).
 final class ImportExportRoundTripTests: XCTestCase {
     var app: XCUIApplication!
@@ -23,7 +23,7 @@ final class ImportExportRoundTripTests: XCTestCase {
     var roundTripPath: URL!
 
     /// Name of the seeded alertmanager — must match the constant used by
-    /// `seedFromLaunchArgumentsIfNeeded` in `AlertmanagerApp.swift`.
+    /// `seedFromLaunchArgumentsIfNeeded` in `ContentView.swift`.
     let seededName = "Test AM"
     let seededURL = "http://localhost:9093"
 
@@ -70,7 +70,7 @@ final class ImportExportRoundTripTests: XCTestCase {
         XCTAssertTrue(sidebarRow.waitForExistence(timeout: 10))
 
         // 2. Trigger Export — app writes the JSON file directly to
-        // `roundTripPath` because of `-uiTestExportPath`.
+        // `roundTripPath` because of `UI_TEST_EXPORT_PATH`.
         openAlertmanagerMenu()
         app.menuItems["Export Configuration"].click()
 
@@ -104,7 +104,7 @@ final class ImportExportRoundTripTests: XCTestCase {
         XCTAssertTrue(sidebarRow.waitForNonExistence(timeout: 5))
 
         // 4. Trigger Import — app reads from `roundTripPath` because of
-        // `-uiTestImportPath`.
+        // `UI_TEST_IMPORT_PATH`.
         openAlertmanagerMenu()
         app.menuItems["Import Configuration"].click()
 


### PR DESCRIPTION
One commit per finding category from the repository analysis.

---

**refactor(alerts): consolidate aggregation and deep-link construction**

AlertAggregator existed to keep the "collect, dedupe by fingerprint,
apply filter" pipeline in one place, but FilterDetailView and
MenuBarContentView each carried their own copy. The menu bar variant
also filtered before deduplicating, so an alert whose state differs
across alertmanagers (e.g. silenced in the dedup winner) could appear
in the menu bar while the detail view hid it. Both now go through the
new AlertAggregator.alertsWithSources, which preserves the
alert-to-alertmanager pairing the views need for deep links and makes
dedup-before-filter the single semantic everywhere; FilterDetailView's
per-row findAlertmanager reverse lookup becomes unnecessary.

Silence-URL construction (including the Grafana datasource-name
lookup) was duplicated between AlertRowView and NotificationService;
it now lives in AlertmanagerService.resolveSilenceURL. As a side
effect notifications no longer offer a silence action for a Grafana
backend without a configured datasource — previously they linked to a
broken URL. Dashboard and panel URLs in notifications now use the
existing AlertDeepLinks helpers instead of inline string building.

The toolbar search field, the empty-state placeholder, and the sidebar
count badge were copy-pasted across views; they are now the shared
AlertSearchField, ContentPlaceholderView, and CountBadge components.

---

**docs: align comments and AGENTS.md with the implementation**

AGENTS.md described a Grafana integration that no longer exists —
plural grafanaAlertmanagers iterated by datasource name and a
grafanaAlertmanagerSource tag on every alert. The model stores a
single datasource UID and alerts are never tagged; the producing
alertmanager is re-resolved from the per-AM caches. The notification
category count (31, ALERT_0 deliberately unregistered) and the code
layout (AlertMarkdown, UpdateCheckService) are corrected too, and the
CI note now mentions the existing packaging workflows.

Stale code comments fixed alongside: the menu bar panel is 500x600,
the UI-test seed/export/import hooks are environment variables (not
launch arguments) handled in ContentView (not AlertmanagerApp), the
Grafana alerts path uses the UID (not the name), AlertRowView's
isExpanded consumer is ContentView's alert-detail pane (AlertDetailView
never existed), and an empty state selection in FilterFormView matches
all states rather than none.

---

**refactor: remove dead code and align inconsistent behavior**

- Mark NotificationUserInfoKey and NotificationActionIdentifier as
  nonisolated and use the constants everywhere. The notification
  delegate previously had to duplicate them as string literals because
  the project-wide MainActor default isolated the enums, and
  NotificationActionIdentifier ended up entirely unused.
- Drop the never-posted .filterDidUpdate notification name and the
  never-set isLoading spinner state in SidebarFilterRowView.
- Report non-2xx HTTP responses as the new
  AlertmanagerError.serverError(statusCode:) instead of collapsing
  them into a generic URLError, so the sidebar tooltip and the detail
  error state show which status the backend actually returned.
- Save explicitly in AlertmanagerFormView and dismiss only on success,
  matching FilterFormView, so both form sheets persist the same way.

---

**test(import): restore settings mutated by import tests**

ImportExportManager.importData writes imported settings straight into
SettingsManager.shared — the real UserDefaults of the test host — and
exportData embeds the current settings into every export, so the
round-trip tests clobbered the developer's actual refresh interval and
menu-bar filter selection on every run. SettingsManagerTests already
saves and restores carefully; the import tests now do the same via a
SettingsSnapshot helper captured at test start and restored on exit.